### PR TITLE
Replace deprecated Adios functions

### DIFF
--- a/Io/Adios.lua
+++ b/Io/Adios.lua
@@ -1,11 +1,11 @@
 -- Gkyl ------------------------------------------------------------------------
 --
--- Lua wrapper for ADIOS
+-- Lua wrapper for ADIOS.
 --    _______     ___
 -- + 6 @ |||| # P ||| +
 --------------------------------------------------------------------------------
 
--- don't bother if ADIOS is not built in
+-- Don't bother if ADIOS is not built in.
 assert(GKYL_HAVE_ADIOS, "Gkyl was not built with ADIOS!")
 
 local ffi  = require "ffi"
@@ -14,36 +14,39 @@ local xsys = require "xsys"
 local new, copy, fill, sizeof, typeof, metatype = xsys.from(ffi,
      "new, copy, fill, sizeof, typeof, metatype")
 
-require "Io._AdiosCdef" -- load FFI binding
-require "Io._AdiosReadCdef" -- load FFI binding for read API
+require "Io._AdiosCdef"     -- Load FFI binding.
+require "Io._AdiosReadCdef" -- Load FFI binding for read API.
 
 local _M = {}
 
--- constants from enum ADIOS_FLAG
+-- Constants from enum ADIOS_FLAG.
 _M.flag_yes = ffiC.adios_flag_yes
-_M.flag_no = ffiC.adios_flag_no
--- constants from enum ADIOS_DATATYPES
-_M.unknown = ffiC.adios_unknown
-_M.byte = ffiC.adios_byte
-_M.short = ffiC.adios_short
-_M.integer = ffiC.adios_integer
-_M.long = ffiC.adios_long
-_M.unsigned_byte = ffiC.adios_unsigned_byte
-_M.unsigned_short = ffiC.adios_unsigned_short
+_M.flag_no  = ffiC.adios_flag_no
+-- Constants from enum ADIOS_DATATYPES.
+_M.unknown          = ffiC.adios_unknown
+_M.byte             = ffiC.adios_byte
+_M.short            = ffiC.adios_short
+_M.integer          = ffiC.adios_integer
+_M.long             = ffiC.adios_long
+_M.unsigned_byte    = ffiC.adios_unsigned_byte
+_M.unsigned_short   = ffiC.adios_unsigned_short
 _M.unsigned_integer = ffiC.adios_unsigned_integer
-_M.unsigned_long = ffiC.adios_unsigned_long
-_M.real = ffiC.adios_real
-_M.double = ffiC.adios_double
-_M.long_double = ffiC.adios_long_double
-_M.string = ffiC.adios_string
-_M.complex = ffiC.adios_complex
-_M.double_complex = ffiC.adios_double_complex
-_M.string_array = ffiC.adios_string_array
+_M.unsigned_long    = ffiC.adios_unsigned_long
+_M.real             = ffiC.adios_real
+_M.double           = ffiC.adios_double
+_M.long_double      = ffiC.adios_long_double
+_M.string           = ffiC.adios_string
+_M.complex          = ffiC.adios_complex
+_M.double_complex   = ffiC.adios_double_complex
+_M.string_array     = ffiC.adios_string_array
 
--- ADIOS read methods from adios_read
+-- ADIOS read methods from adios_read.
 _M.read_method_bp = ffiC.ADIOS_READ_METHOD_BP
 
--- adios_init_noxml
+-- ADIOS contiguous block selection.
+_M.selBoundingbox = ffiC.ADIOS_SELECTION_BOUNDINGBOX
+
+-- adios_init_noxml.
 function _M.init_noxml(comm)
    local err = ffiC.adios_init_noxml(comm)
 end
@@ -54,7 +57,7 @@ end
 
 -- adios_declare_group
 function _M.declare_group(name, time_index, stats)
-   local id = new("int64_t[1]")
+   local id  = new("int64_t[1]")
    local err = ffiC.adios_declare_group(id, name, time_index, stats)
    return id
 end
@@ -80,7 +83,7 @@ end
 
 -- adios_open
 function _M.open(group_name, name, mode, comm)
-   local id = new("int64_t[1]")
+   local id  = new("int64_t[1]")
    local err = ffiC.adios_open(id, group_name, name, mode, comm)
    return id
 end
@@ -144,6 +147,11 @@ function _M.selection_boundingbox(ndim, start, count)
    return ffiC.adios_selection_boundingbox(ndim, start:data(), count:data())
 end
 
+-- adios_schedule_read
+function _M.schedule_read(fp, sel, name, from_steps, nsteps, data)
+   return ffiC.adios_schedule_read(fp, sel, name, from_steps, nsteps, data)
+end
+
 -- adios_schedule_read_byid
 function _M.schedule_read_byid(fp, sel, varid, from_steps, nsteps, data)
    return ffiC.adios_schedule_read_byid(fp, sel, varid, from_steps, nsteps, data:data())
@@ -157,7 +165,7 @@ end
 -- adios_get_attr_byid
 function _M.get_attr_byid(fp, attrid) --> type, size, void* to data
    local typePtr, sizePtr = ffi.new("int[1]"), ffi.new("int[1]")
-   local voidPtr = ffi.new(typeof("void *[1]"))
+   local voidPtr          = ffi.new(typeof("void *[1]"))
    ffiC.adios_get_attr_byid(fp, attrid, typePtr, sizePtr, voidPtr)
    return typePtr[0], sizePtr[0], voidPtr[0]
 end

--- a/Io/_AdiosCdef.lua
+++ b/Io/_AdiosCdef.lua
@@ -5,7 +5,7 @@
 -- + 6 @ |||| # P ||| +
 --------------------------------------------------------------------------------
 
-local ffi  = require "ffi"
+local ffi = require "ffi"
 local Mpi = require "Comm.Mpi"
 
 -- Cut and paste from ADIOS header file, comments unchanged: Perhaps

--- a/Unit/test_AdiosRestarts.lua
+++ b/Unit/test_AdiosRestarts.lua
@@ -1,0 +1,216 @@
+-- Gkyl ------------------------------------------------------------------------
+--
+-- Test for ADIOS-based restarts.
+--    _______     ___
+-- + 6 @ |||| # P ||| +
+--------------------------------------------------------------------------------
+
+local Plasma      = require("App.PlasmaOnCartGrid").VlasovMaxwell
+local lfs         = require "lfs"
+local AdiosReader = require "Io.AdiosReader"
+local Mpi         = require "Comm.Mpi"
+
+local function log(msg)
+   local rank = Mpi.Comm_rank(Mpi.COMM_WORLD)
+   if rank == 0 then
+      print(msg)
+   end
+end
+
+local verboseLog = function (msg) log(msg) end
+
+local function twoStreamP2(endTime, frames, decomp, isRestart)
+   if isRestart then
+      GKYL_COMMANDS[1] = "restart"
+   end
+   -- This is the same two-stream p2 simulation as in Regression.
+   knumber      = 0.5    -- Wave-number.
+   elVTerm      = 0.2    -- Electron thermal velocity.
+   vDrift       = 1.0    -- Drift velocity.
+   perturbation = 1.0e-6 -- Distribution function perturbation.
+   elVTerm      = 0.2    -- Electron thermal velocity.
+   
+   vlasovApp = Plasma.App {
+      logToFile = false,
+   
+      tEnd        = endTime,            -- End time.
+      nFrame      = frames,             -- Number of output frames.
+      lower       = {-math.pi/knumber}, -- Configuration space lower left.
+      upper       = { math.pi/knumber}, -- Configuration space upper right.
+      cells       = {64},               -- Configuration space cells.
+      basis       = "serendipity",      -- One of "serendipity" or "maximal-order".
+      polyOrder   = 2,                  -- Polynomial order.
+      timeStepper = "rk3",              -- One of "rk2" or "rk3".
+   
+      -- Decomposition for configuration space.
+      decompCuts = decomp,   -- Cuts in each configuration direction.
+      useShared  = false,    -- If to use shared memory.
+   
+      -- Boundary conditions for configuration space
+      periodicDirs = {1}, -- Periodic directions.
+   
+      -- Electrons.
+      elc = Plasma.Species {
+         charge = -1.0, mass = 1.0,
+         -- Velocity space grid.
+         lower = {-6.0},
+         upper = {6.0},
+         cells = {32},
+         -- Initial conditions.
+         init = function (t, xn)
+            local x, v  = xn[1], xn[2]
+            local alpha = perturbation
+            local k     = knumber
+            local vt    = elVTerm
+   
+            local fv = 1/math.sqrt(8*math.pi*vt^2)*(math.exp(-(v-vDrift )^2/(2*vt^2))+math.exp(-(v+vDrift)^2/(2*vt^2)))
+            return (1+alpha*math.cos(k*x))*fv
+         end,
+         evolve = true, -- Evolve species?
+   
+         diagnosticMoments = { "M0", "M1i", "M2" }
+      },
+   
+      -- Field solver.
+      field = Plasma.Field {
+         epsilon0 = 1.0, mu0 = 1.0,
+         init = function (t, xn)
+            local alpha = perturbation
+            local k     = knumber
+            return -alpha*math.sin(k*xn[1])/k, 0.0, 0.0, 0.0, 0.0, 0.0
+         end,
+         evolve = true, -- Evolve field?
+      },
+   }
+   -- Run application.
+   vlasovApp:run()
+end
+
+-- (from Tool/runregression.lua) function to compare floats: the comparison is normalized to the
+-- maximum value of the field being compared. Perhaps this is too
+-- "coarse" but a direct comparison of floats is very tricky.
+local function check_equal_numeric(expected, actual, maxVal)
+   if maxVal < GKYL_MIN_DOUBLE then
+      return math.max(expected-actual) > 10*GKYL_MIN_DOUBLE
+   end
+   if math.max(expected-actual)/maxVal > 1e-12 then
+      return false
+   end
+   return true
+end
+
+-- (from Tool/runregression.lua) relative difference between two numbers (NOT SURE IF THIS IS BEST
+-- WAY TO DO THINGS)
+local function get_relative_numeric(expected, actual, maxVal)
+   if maxVal < 1e-15 then
+      return math.max(expected-actual)
+   else
+      return math.abs(expected-actual)/maxVal
+   end
+end
+
+-- (from Tool/runregression.lua) Calculates maximum value in supplied field.
+local function maxValueInField(fld)
+   local maxVal = 0.0
+   for i = 1, fld:size() do
+      maxVal = math.max(maxVal, math.abs(fld[i]))
+   end
+   return maxVal
+end
+
+-- Function to compare files (from Tool/runregression.lua).
+local function compareFiles(f1, f2)
+   verboseLog(string.format("Comparing %s %s ...\n", f1, f2))
+   if not lfs.attributes(f1) or not lfs.attributes(f2) then
+      verboseLog(string.format(
+                    " ... files %s and/or %s do not exist!\n", f1, f2))
+      return false
+   end
+
+   local r1, r2 = AdiosReader.Reader(f1), AdiosReader.Reader(f2)
+
+   local cmpPass = true
+   local currMaxDiff = 0.0
+
+   if r1:hasVar("CartGridField") and r2:hasVar("CartGridField") then
+      -- compare CartField
+      local d1, d2 = r1:getVar("CartGridField"):read(), r2:getVar("CartGridField"):read()
+
+      if d1:size() ~= d2:size() then
+         verboseLog(string.format(
+                       " ... CartGridField in files %s and %s not the same size!\n", f1, f2))
+         return false
+      end
+
+      local maxVal = maxValueInField(d1) -- maximum value (for numeric comparison)
+      for i = 1, d1:size() do
+         if check_equal_numeric(d1[i], d2[i], maxVal) == false then
+            currMaxDiff = math.max(currMaxDiff, get_relative_numeric(d1[i], d2[i], maxVal))
+            cmpPass = false
+         end
+      end
+   elseif r1:hasVar("TimeMesh") and r2:hasVar("TimeMesh") then
+      -- Compare DynVector
+      local d1, d2 = r1:getVar("Data"):read(), r2:getVar("Data"):read()
+      if d1:size() ~= d2:size() then
+         verboseLog(string.format(
+                       " ... DynVector in files %s and %s not the same size!\n", f1, f2))
+         return false
+      end
+
+      local maxVal = maxValueInField(d1) -- maximum value (for numeric comparison)
+      for i = 1, d1:size() do
+         if check_equal_numeric(d1[i], d2[i], maxVal) == false then
+            currMaxDiff = math.max(currMaxDiff, get_relative_numeric(d1[i], d2[i], maxVal))
+            cmpPass = false
+         end
+      end
+   end
+
+   if cmpPass == false then
+      verboseLog(string.format(" ... relative error in file %s is %g ...\n", f2, currMaxDiff))
+   end
+
+   r1:close(); r2:close()
+
+   return cmpPass
+end
+
+
+-- Run one simulation until the end to produce reference data.
+twoStreamP2(10.0, 2, {1}, false)
+-- Copy over the moments and distribution function to reference files. 
+fileName    = {GKYL_OUT_PREFIX .. "_elc_2.bp",
+               GKYL_OUT_PREFIX .. "_elc_M0_2.bp",
+               GKYL_OUT_PREFIX .. "_elc_M1i_2.bp",
+               GKYL_OUT_PREFIX .. "_elc_M2_2.bp"}
+fileNameRef = {GKYL_OUT_PREFIX .. "_elc_2ref.bp",
+               GKYL_OUT_PREFIX .. "_elc_M0_2ref.bp",
+               GKYL_OUT_PREFIX .. "_elc_M1i_2ref.bp",
+               GKYL_OUT_PREFIX .. "_elc_M2_2ref.bp"}
+for i,v in pairs(fileName) do
+   os.execute("cp " .. fileName[i] .. " " .. fileNameRef[i])
+end
+
+-- Run first half of the simulation.
+twoStreamP2(5.0,1,{1},false)
+-- Restart and run the second half of the simulation.
+twoStreamP2(10.0,2,{1},true)
+
+print(' ')
+-- Compare the outputs of this last run to reference data produced above.
+compFlag      = true
+areFilesEqual = true
+for i,v in pairs(fileName) do
+   compFlag = compareFiles(fileNameRef[i],fileName[i])
+   areFilesEqual = areFilesEqual and compFlag
+end
+
+if not areFilesEqual then
+   print(" --> ERROR <--- ")
+   print(" Files are NOT equal => restarts are BROKEN ")
+else
+   print(" No errors in restarts detected.")
+end
+print(" ")
+

--- a/Unit/test_AdiosRestarts.sh
+++ b/Unit/test_AdiosRestarts.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#.
+#.Test simulation restart Adios infrastructure for parallel jobs.
+#.
+#.In this script the user must specify:
+#.  endTime: final simulation timetime.
+#.  frames:  number of frames to output
+#.  decomp:  MPI decomposition.
+#.for each of 3 runs of the input file chosen. The name of the input file
+#.must be the same for all 3 runs, and must match the string passed to
+#.the file comparison (test_AdiosRestartsCompare) through `simulationName`.
+#.Also pass the frame number through 'compareFrame' to test_AdiosRestartsCompare,
+#.it must be the same number as the frame of the files copied after run #1.
+#.
+#.Lines commented are to switch between serial tests on a laptop,
+#.and tests of parallel restarts on a cluster.
+#.
+
+#module load intel/2018-01
+
+#.For some reason we need to specify the full path to gkyl command.
+export gComDir="$HOME/gkylsoft/gkyl/bin"
+#export mpiComDir="$HOME/gkylsoft/openmpi-3.1.2/bin/"
+
+#.Run #1: do a first simulation to produce reference data.
+#$mpiComDir/mpirun -n 2 $gComDir/gkyl -e "endTime=10.0; frames=2; decomp={1}" two-stream-p2.lua
+$gComDir/gkyl -e "endTime=10.0; frames=2; decomp={1}" two-stream-p2.lua
+
+#.Copy the distribution function and its moments into reference files.
+cp two-stream-p2_elc_2.bp two-stream-p2_elc_2ref.bp
+cp two-stream-p2_elc_M0_2.bp two-stream-p2_elc_M0_2ref.bp
+cp two-stream-p2_elc_M1i_2.bp two-stream-p2_elc_M1i_2ref.bp
+cp two-stream-p2_elc_M2_2.bp two-stream-p2_elc_M2_2ref.bp
+cp two-stream-p2_field_2.bp two-stream-p2_field_2ref.bp
+
+#.Run #2: first half of the simulation with same number of processes as reference run.
+#$mpiComDir/mpirun -n 2 $gComDir/gkyl -e "endTime=5.0; frames=1; decomp={2}" two-stream-p2.lua
+$gComDir/gkyl -e "endTime=5.0; frames=1; decomp={1}" two-stream-p2.lua
+
+#.Run #3: restart simulation with a different number of processes.
+#$mpiComDir/mpirun -n 4 $gComDir/gkyl -e "endTime=10.0; frames=2; decomp={4}" two-stream-p2.lua restart
+$gComDir/gkyl -e "endTime=10.0; frames=2; decomp={1}" two-stream-p2.lua restart
+
+#.Run a Lua script that compares files from runs #1 and #3.
+$gComDir/gkyl -e "simulationName=\"two-stream-p2\"; compareFrame=2" test_AdiosRestartsCompare.lua

--- a/Unit/test_AdiosRestartsCompare.lua
+++ b/Unit/test_AdiosRestartsCompare.lua
@@ -133,8 +133,8 @@ for i,v in pairs(fileName) do
 end
 
 if not areFilesEqual then
-   print(" --> ERROR <--- ")
-   print(" Files are NOT equal => restarts are BROKEN ")
+   print(" --> BEWARE <--- ")
+   print(" Files are NOT equal => restarts are broken OR triggers are causing a small, negligible difference ")
 else
    print(" No errors in restarts detected.")
 end

--- a/Unit/two-stream-p2.lua
+++ b/Unit/two-stream-p2.lua
@@ -1,0 +1,64 @@
+-- Gkyl ------------------------------------------------------------------------
+local Plasma = require("App.PlasmaOnCartGrid").VlasovMaxwell
+
+-- This is the same two-stream p2 simulation as in Regression.
+knumber      = 0.5    -- Wave-number.
+elVTerm      = 0.2    -- Electron thermal velocity.
+vDrift       = 1.0    -- Drift velocity.
+perturbation = 1.0e-6 -- Distribution function perturbation.
+elVTerm      = 0.2    -- Electron thermal velocity.
+
+vlasovApp = Plasma.App {
+   logToFile = false,
+
+   tEnd        = endTime,            -- End time.
+   nFrame      = frames,             -- Number of output frames.
+   lower       = {-math.pi/knumber}, -- Configuration space lower left.
+   upper       = { math.pi/knumber}, -- Configuration space upper right.
+   cells       = {64},               -- Configuration space cells.
+   basis       = "serendipity",      -- One of "serendipity" or "maximal-order".
+   polyOrder   = 2,                  -- Polynomial order.
+   timeStepper = "rk3",              -- One of "rk2" or "rk3".
+
+   -- Decomposition for configuration space.
+   decompCuts = decomp,   -- Cuts in each configuration direction.
+   useShared  = false,    -- If to use shared memory.
+
+   -- Boundary conditions for configuration space
+   periodicDirs = {1}, -- Periodic directions.
+
+   -- Electrons.
+   elc = Plasma.Species {
+      charge = -1.0, mass = 1.0,
+      -- Velocity space grid.
+      lower = {-6.0},
+      upper = {6.0},
+      cells = {32},
+      -- Initial conditions.
+      init = function (t, xn)
+         local x, v  = xn[1], xn[2]
+         local alpha = perturbation
+         local k     = knumber
+         local vt    = elVTerm
+
+         local fv = 1/math.sqrt(8*math.pi*vt^2)*(math.exp(-(v-vDrift )^2/(2*vt^2))+math.exp(-(v+vDrift)^2/(2*vt^2)))
+         return (1+alpha*math.cos(k*x))*fv
+      end,
+      evolve = true, -- Evolve species?
+
+      diagnosticMoments = { "M0", "M1i", "M2" }
+   },
+
+   -- Field solver.
+   field = Plasma.Field {
+      epsilon0 = 1.0, mu0 = 1.0,
+      init = function (t, xn)
+         local alpha = perturbation
+         local k     = knumber
+         return -alpha*math.sin(k*xn[1])/k, 0.0, 0.0, 0.0, 0.0, 0.0
+      end,
+      evolve = true, -- Evolve field?
+   },
+}
+-- Run application.
+vlasovApp:run()


### PR DESCRIPTION
Tested with 1x1v two-stream and 2x2v weibel. As far as I can tell the errors are no worse than they already were, but now we can restart with a different MPI decomposition.