### PR TITLE
Moving from linking objects to creating shared libraries

### DIFF
--- a/Comm/wscript
+++ b/Comm/wscript
@@ -10,9 +10,9 @@ def build(bld):
     
     # only build if in parallel
     if bld.env.MPI_FOUND:
-        bld.objects(
+        bld.shlib(
             source = 'GkMpiFuncs.cpp',
-            target = 'comm',
+            target = 'gkcomm', name = 'comm', vnum = '1.0',
             includes = '.',
             use = 'MPI'
         )    

--- a/DataStruct/wscript
+++ b/DataStruct/wscript
@@ -6,8 +6,8 @@
 import os
 
 def build(bld):
-    bld.objects(
+    bld.shlib(
         source = 'CartFieldImpl.cpp',
-        target = 'datastruct',
+        target = 'gkdatastruct', name = 'datastruct', vnum = '1.0',
         includes = '.'
     )

--- a/Eq/wscript
+++ b/Eq/wscript
@@ -6,7 +6,7 @@
 import os
 
 def build(bld):
-    bld.objects(source = r"""
+    bld.shlib(source = r"""
     TenMomentImpl.cpp
 
     incompEulerData/IncompEulerSer2xP1.cpp
@@ -258,6 +258,9 @@ def build(bld):
     Positivity.cpp
 
     """,
-    target = 'eq', use='EIGEN', includes = '. incompEulerData lboData constDiffusionData maxwellData vlasovData pbData gkData ../Updater/binOpCalcData'
+              name = 'eq',
+              target = 'gkeq', use='EIGEN', includes = '. incompEulerData lboData constDiffusionData maxwellData vlasovData pbData gkData ../Updater/binOpCalcData',
+              vnum = '1.0',
+              
     )
 

--- a/Grid/wscript
+++ b/Grid/wscript
@@ -6,8 +6,8 @@
 import os
 
 def build(bld):
-    bld.objects(
+    bld.shlib(
         source = 'RectCartImpl.cpp',
-        target = 'grid',
+        target = 'gkgrid', name = 'grid', vnum = '1.0',
         includes = '.'
     )

--- a/Lib/wscript
+++ b/Lib/wscript
@@ -6,9 +6,9 @@
 import os
 
 def build(bld):
-    bld.objects(source = r"""
+    bld.shlib(source = r"""
     gkyl_ipow.cpp
     whereami.c
     base64.cpp
     lfs.c""",
-    use = "LUAJIT", includes = '.', target = 'lib')
+              use = "LUAJIT", includes = '.', target = 'gklib', name = 'lib', vnum = '1.0')

--- a/Proto/wscript
+++ b/Proto/wscript
@@ -6,7 +6,7 @@
 import os
 
 def build(bld):
-    bld.objects(source = r"""
+    bld.shlib(source = r"""
     Fpo/fpoMomsKernelP1.cpp
     Fpo/fpoMomsKernelP2.cpp
 
@@ -19,4 +19,4 @@ def build(bld):
     Fpo/fpoDiffKernelP1.cpp
     Fpo/fpoDiffKernelP2.cpp
     """,
-    includes = '. Fpo', use='Eigen MPI', target = 'proto')
+              includes = '. Fpo', use='Eigen MPI lib', target = 'gkproto', name='proto', vnum = '1.0')

--- a/Updater/wscript
+++ b/Updater/wscript
@@ -6,7 +6,7 @@
 import os
 
 def build(bld):
-    bld.objects(source = r"""
+    bld.shlib(source = r"""
     MomentSrcCommon.cpp
     FiveMomentSrcImpl.cpp
     TenMomentSrcImpl.cpp
@@ -205,5 +205,5 @@ def build(bld):
     EvalOnNodesImpl.cpp
 
     """,
-    includes = '. spitzerNuCalcData primMomentsCalcData binOpCalcData lagrangeFixData momentCalcData confToPhaseData', use='EIGEN MPI', target = 'updater')
+              includes = '. spitzerNuCalcData primMomentsCalcData binOpCalcData lagrangeFixData momentCalcData confToPhaseData', use='lib EIGEN MPI', target = 'gkupdater', name = 'updater', vum = '1.0')
     

--- a/install-deps/build-luajit-beta3.sh
+++ b/install-deps/build-luajit-beta3.sh
@@ -17,8 +17,3 @@ git checkout v2.1
 make PREFIX=$PREFIX CC=$CC
 make XCFLAGS=-DLUAJIT_ENABLE_GC64 install PREFIX=$PREFIX
 
-# delete dynamic libraries
-cmd="rm -rf $PREFIX/lib/*.dylib $PREFIX/lib/*.so*"
-echo $cmd
-$cmd
-

--- a/install-deps/build-luajit-openresty.sh
+++ b/install-deps/build-luajit-openresty.sh
@@ -22,8 +22,3 @@ ln -sf $PREFIX $GKYLSOFT/luajit
 # (luarocks) needing lua executable to run
 ln -sf $PREFIX/bin/luajit-2.1.0-beta3 $PREFIX/bin/lua
 
-# delete dynamic libraries
-cmd="rm -rf $PREFIX/lib/*.dylib $PREFIX/lib/*.so*"
-echo $cmd
-$cmd
-

--- a/install-deps/build-luajit-ppcle.sh
+++ b/install-deps/build-luajit-ppcle.sh
@@ -21,9 +21,3 @@ ln -sf $PREFIX $GKYLSOFT/luajit
 # soft-link executable name "lua". This allows running various tools
 # (luarocks) needing lua executable to run
 ln -sf $PREFIX/bin/luajit-2.1.0-ppcle $PREFIX/bin/lua
-
-# delete dynamic libraries
-cmd="rm -rf $PREFIX/lib/*.dylib $PREFIX/lib/*.so*"
-echo $cmd
-$cmd
-

--- a/install-deps/build-zmq.sh
+++ b/install-deps/build-zmq.sh
@@ -20,7 +20,3 @@ make install
 # softlink to make finding easier
 ln -sf $PREFIX $GKYLSOFT/zeromq
 
-# delete dynamic libraries
-cmd="rm -rf $PREFIX/lib/*.dylib $PREFIX/lib/*.so*"
-echo $cmd
-$cmd

--- a/machines/mkdeps.stampede.sh
+++ b/machines/mkdeps.stampede.sh
@@ -1,5 +1,6 @@
 module load intel/18.0.2
 module load impi/18.0.2
+export PATH=$PATH:/usr/sbin/
 # if we are in machines directory, go up a directory
 if [ `dirname "$0"` == "." ] 
   then

--- a/sqlite3/wscript
+++ b/sqlite3/wscript
@@ -6,6 +6,6 @@
 import os
 
 def build(bld):
-    bld.objects(source = r"""
+    bld.shlib(source = r"""
     sqlite3.c""",
-    use = "LUAJIT", includes = '.', target = 'sqlite3')
+    use = "LUAJIT", includes = '.', target = 'gksqlite3', name = 'sqlite3', vnum = '1.0')

--- a/waf_tools/luajit.py
+++ b/waf_tools/luajit.py
@@ -21,16 +21,16 @@ def check_luajit(conf):
         conf.env.INCLUDES_LUAJIT = [conf.options.gkylDepsDir+'/luajit/include/luajit-2.1']
         
     if conf.options.luaJitLibDir:
-        conf.env.STLIBPATH_LUAJIT = conf.options.luaJitLibDir
+        conf.env.LIBPATH_LUAJIT = conf.options.luaJitLibDir
     else:
-        conf.env.STLIBPATH_LUAJIT = [conf.options.gkylDepsDir+'/luajit/lib']
+        conf.env.LIBPATH_LUAJIT = [conf.options.gkylDepsDir+'/luajit/lib']
 
     if conf.options.luaJitShrDir:
         conf.env.SHARE_LUAJIT = conf.options.luaJitShrDir
     else:
         conf.env.SHARE_LUAJIT = conf.options.gkylDepsDir+'/luajit/share/luajit'
 
-    conf.env.STLIB_LUAJIT = ["luajit-5.1"]
+    conf.env.LIB_LUAJIT = ["luajit-5.1"]
         
     conf.start_msg('Checking for LUAJIT')
     conf.check(header_name='lua.hpp', features='cxx cxxprogram', use="LUAJIT", mandatory=True)

--- a/waf_tools/zmq.py
+++ b/waf_tools/zmq.py
@@ -22,11 +22,11 @@ def check_zmq(conf):
 
     # lib directory
     if conf.options.zmqLibDir:
-        conf.env.STLIBPATH_ZMQ = conf.options.zmqLibDir
-        conf.env.STLIB_ZMQ = ["zmq"]
+        conf.env.LIBPATH_ZMQ = conf.options.zmqLibDir
+        conf.env.LIB_ZMQ = ["zmq"]
     else:
-        conf.env.STLIBPATH_ZMQ = [conf.options.gkylDepsDir+'/zeromq/lib']
-        conf.env.STLIB_ZMQ = ["zmq"]
+        conf.env.LIBPATH_ZMQ = [conf.options.gkylDepsDir+'/zeromq/lib']
+        conf.env.LIB_ZMQ = ["zmq"]
          
     conf.start_msg('Checking for ZMQ')
     try:

--- a/wscript
+++ b/wscript
@@ -215,6 +215,12 @@ def buildExec(bld):
         # we need to append special flags to get stuff to work on a 64 bit Mac
         EXTRA_LINK_FLAGS.append('-pagezero_size 10000 -image_base 100000000')
 
+    # Link flags on Linux
+    if platform.system() == 'Linux':
+        bld.env.LINKFLAGS_cstlib = ['-Wl,-Bstatic,-E']
+        bld.env.LINKFLAGS_cxxstlib = ['-Wl,-Bstatic,-E']
+        bld.env.STLIB_MARKER = '-Wl,-Bstatic,-E'        
+
     useList = 'lib datastruct eq unit comm updater proto basis grid LUAJIT ADIOS EIGEN MPI M DL'
     if bld.env['USE_SQLITE']:
         useList = 'sqlite3 ' + useList

--- a/wscript
+++ b/wscript
@@ -215,13 +215,6 @@ def buildExec(bld):
         # we need to append special flags to get stuff to work on a 64 bit Mac
         EXTRA_LINK_FLAGS.append('-pagezero_size 10000 -image_base 100000000')
 
-    # slightly modify Linux linker that thinks that he is smart and is
-    # not exporting the symbols that are only used in the Lua part
-    if platform.system() == 'Linux':
-        bld.env.LINKFLAGS_cstlib = ['-Wl,-Bstatic,-E']
-        bld.env.LINKFLAGS_cxxstlib = ['-Wl,-Bstatic,-E']
-        bld.env.STLIB_MARKER = '-Wl,-Bstatic,-E'
-
     useList = 'lib datastruct eq unit comm updater proto basis grid LUAJIT ADIOS EIGEN MPI M DL'
     if bld.env['USE_SQLITE']:
         useList = 'sqlite3 ' + useList

--- a/wscript
+++ b/wscript
@@ -233,7 +233,7 @@ def buildExec(bld):
         includes = 'Unit Lib Comm',
         use = useList,
         linkflags = EXTRA_LINK_FLAGS,
-        rpath = [bld.env.RPATH, bld.env.LIBDIR ],
+        rpath = [bld.env.RPATH, bld.env.LIBDIR, bld.env.LIBPATH_LUAJIT],
         lib = 'pthread ' + bld.env.EXTRALIBS
     )
 

--- a/wscript
+++ b/wscript
@@ -60,9 +60,6 @@ class GitTip(Task.Task):
 
 def build(bld):
 
-    # determine Mercurial version (THIS NEEDS TO UPDATED TO WORK WITH
-    # GIT)
-
     gitTip = GitTip(env=bld.env)
     gitTip.set_outputs(bld.path.find_or_declare('gkylgittip.h'))
     bld.add_to_group(gitTip)
@@ -233,7 +230,7 @@ def buildExec(bld):
         includes = 'Unit Lib Comm',
         use = useList,
         linkflags = EXTRA_LINK_FLAGS,
-        rpath = [bld.env.RPATH, bld.env.LIBDIR, bld.env.LIBPATH_LUAJIT],
+        rpath = [bld.env.LIBDIR, bld.env.LIBPATH_LUAJIT].append(bld.env.RPATH),
         lib = 'pthread ' + bld.env.EXTRALIBS
     )
 

--- a/wscript
+++ b/wscript
@@ -224,13 +224,16 @@ def buildExec(bld):
     if bld.env['ZMQ_FOUND']:
         useList = 'ZMQ ' + useList
 
+    # set RPATH (append user specified rpath also)
+    fullRpath = bld.env.RPATH + [bld.env.LIBDIR, bld.env.LIBPATH_LUAJIT]
+
     # build gkyl executable
     bld.program(
         source ='gkyl.cxx', target='gkyl',
         includes = 'Unit Lib Comm',
         use = useList,
         linkflags = EXTRA_LINK_FLAGS,
-        rpath = [bld.env.LIBDIR, bld.env.LIBPATH_LUAJIT].append(bld.env.RPATH),
+        rpath = fullRpath,
         lib = 'pthread ' + bld.env.EXTRALIBS
     )
 


### PR DESCRIPTION
This is a **major change**. We are now no longer linking individual objects into the final gkyl executable, but instead linking shared libraries that are linked to the executable. In general, out philosophy going forward will be use shared libraries going forward. I will send out detailed instructions after the branch merge, but in short, one needs to rebuild LuaJIT and then reconfigure and rebuild. Should be simple. However, ldconfig needs to be in the path. Details to follow.