### PR TITLE
Cuda runtime incorporation: step 1

### DIFF
--- a/Cuda/RunTime.lua
+++ b/Cuda/RunTime.lua
@@ -9,6 +9,9 @@ assert(GKYL_HAVE_CUDA, "Gkyl was not built with CUDA!")
 
 local ffi  = require "ffi"
 local ffiC = ffi.C
+local xsys = require "xsys"
+local new, typeof = xsys.from(ffi,
+     "new, typeof")
 
 local _M = {}
 

--- a/Cuda/RunTime.lua
+++ b/Cuda/RunTime.lua
@@ -1,0 +1,51 @@
+-- Gkyl ------------------------------------------------------------------------
+-- CUDA runtime functions used in Gkeyll
+--    _______     ___
+-- + 6 @ |||| # P ||| +
+--------------------------------------------------------------------------------
+
+-- don't bother if we don't have CUDA
+assert(GKYL_HAVE_CUDA, "Gkyl was not built with CUDA!")
+
+local ffi  = require "ffi"
+local ffiC = ffi.C
+
+local _M = {}
+
+ffi.cdef [[
+  // Run-time information
+  int cudaDriverGetVersion(int *driverVersion);
+
+  // Memory management
+  int cudaMalloc(void **devPtr, size_t size);
+  int cudaFree(void *ptr);
+]]
+
+-- some types for use in CUDA functions
+local int_1 = typeof("int[1]")
+local uint_1 = typeof("unsigned[1]")
+local voidp = typeof("void *[1]")
+
+-- cudaMalloc
+function _M.Malloc(sz)
+   local devPtr = voidp()
+   local err = ffiC.cudaMalloc(devPtr, sz)
+   
+   assert(d, "cudaMalloc: Unable to allocate memory!")
+   return devPtr[0]
+end
+-- cudaFree
+function _M.Free(d)
+   if d then
+      ffiC.cudaFree(d); d = nil
+   end
+end
+
+-- cudaDriverGetVersion
+function _M.DriverGetVersion()
+    local r = int_1()
+    local _ = ffiC.cudaDriverGetVersion(r)
+    return r[0]
+end
+
+return _M

--- a/Gkyl.h
+++ b/Gkyl.h
@@ -39,6 +39,11 @@
 #include <zmq.h>
 #endif
 
+#ifdef HAVE_CUDA_H
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
 #include <lua.hpp>
 
 // Gkyl/Lib includes
@@ -243,6 +248,15 @@ std::string Gkyl::createTopLevelDefs() const {
   varDefs << "GKYL_HAVE_SQLITE3 = true" << std::endl;
 #else
   varDefs << "GKYL_HAVE_SQLITE3 = false" << std::endl;
+#endif
+
+#ifdef HAVE_CUDA_H
+  varDefs << "GKYL_HAVE_CUDA = true" << std::endl;
+  int cuDriverVersion;
+  cudaDriverGetVersion(&cuDriverVersion);
+  varDefs << "GKYL_CUDA_DRIVER_VERSION = " << cuDriverVersion << std::endl;
+#else
+  varDefs << "GKYL_HAVE_CUDA = false" << std::endl;
 #endif
   
   // numeric limits

--- a/Unit/test_Cuda.lua
+++ b/Unit/test_Cuda.lua
@@ -1,0 +1,30 @@
+-- Gkyl ------------------------------------------------------------------------
+--
+-- Test for CUDA runtime API wrappers
+--    _______     ___
+-- + 6 @ |||| # P ||| +
+--------------------------------------------------------------------------------
+
+-- don't do anything if we were not built with CUDA
+if GKYL_HAVE_CUDA == false then
+    return 0
+end
+
+local Unit = require "Unit"
+local cuda = require "Cuda.RunTime"
+
+local assert_equal = Unit.assert_equal
+local stats = Unit.stats
+
+function test_1()
+end
+
+-- Run tests
+test_1()
+
+if stats.fail > 0 then
+   print(string.format("\nPASSED %d tests", stats.pass))
+   print(string.format("**** FAILED %d tests", stats.fail))
+else
+   print(string.format("PASSED ALL %d tests!", stats.pass))
+end

--- a/Unit/test_Cuda.lua
+++ b/Unit/test_Cuda.lua
@@ -17,6 +17,7 @@ local assert_equal = Unit.assert_equal
 local stats = Unit.stats
 
 function test_1()
+    assert_equal(GKYL_CUDA_DRIVER_VERSION, cuda.DriverGetVersion(), "Checking CUDA driver version")
 end
 
 -- Run tests

--- a/gkyl.cxx
+++ b/gkyl.cxx
@@ -111,6 +111,9 @@ void showVersion() {
 #ifdef HAVE_ZMQ_H
   std::cout << " ZeroMQ";
 #endif
+#ifdef HAVE_CUDA_H
+  std::cout << " Cuda";
+#endif
   std::cout << std::endl;
 }
 

--- a/machines/configure.adroit.sh
+++ b/machines/configure.adroit.sh
@@ -36,8 +36,13 @@ ADIOS_LIB_DIR=$HOME/gkylsoft/adios/lib
 # EIGEN options
 EIGEN_INC_DIR=$HOME/gkylsoft/eigen/include/eigen3
 
+# CUDA options
+CUTOOLS_INC_DIR=$CPATH
+CUTOOLS_LIB_DIR=$LIBRARY_PATH
+CUTOOLS_LINK_LIBS=cudart
+
 # You probably do not need to modify the command itself
-cmd="./waf CC=$CC CXX=$CXX MPICC=$MPICC MPICXX=$MPICXX --out=$OUT --prefix=$PREFIX --cxxflags=$CXXFLAGS --luajit-inc-dir=$LUAJIT_INC_DIR --luajit-lib-dir=$LUAJIT_LIB_DIR --luajit-share-dir=$LUAJIT_SHARE_DIR $ENABLE_MPI --mpi-inc-dir=$MPI_INC_DIR --mpi-lib-dir=$MPI_LIB_DIR --mpi-link-libs=$MPI_LINK_LIBS $ENABLE_ADIOS --adios-inc-dir=$ADIOS_INC_DIR --adios-lib-dir=$ADIOS_LIB_DIR configure"
+cmd="./waf CC=$CC CXX=$CXX MPICC=$MPICC MPICXX=$MPICXX --out=$OUT --prefix=$PREFIX --cxxflags=$CXXFLAGS --luajit-inc-dir=$LUAJIT_INC_DIR --luajit-lib-dir=$LUAJIT_LIB_DIR --luajit-share-dir=$LUAJIT_SHARE_DIR $ENABLE_MPI --mpi-inc-dir=$MPI_INC_DIR --mpi-lib-dir=$MPI_LIB_DIR --mpi-link-libs=$MPI_LINK_LIBS $ENABLE_ADIOS --adios-inc-dir=$ADIOS_INC_DIR --adios-lib-dir=$ADIOS_LIB_DIR --cuda-inc-dir=$CUTOOLS_INC_DIR --cuda-lib-dir=$CUTOOLS_LIB_DIR configure"
 # if we are in machines directory, go up a directory before executing cmd
 if [ `dirname "$0"` == "." ] 
   then

--- a/machines/configure.adroit.sh
+++ b/machines/configure.adroit.sh
@@ -3,7 +3,7 @@
 # Edit the paths and options in the following command to suit your system
 module load intel
 module load intel-mpi
-# CUDA
+module load cudatoolkit/10.1
 
 # Build directory
 OUT=build

--- a/machines/configure.adroit.sh
+++ b/machines/configure.adroit.sh
@@ -3,6 +3,7 @@
 # Edit the paths and options in the following command to suit your system
 module load intel
 module load intel-mpi
+# CUDA
 
 # Build directory
 OUT=build

--- a/waf_tools/cutools.py
+++ b/waf_tools/cutools.py
@@ -6,29 +6,32 @@ import os, glob, types
 from waflib.Configure import conf
 
 def options(opt):
-    opt.add_option('--cutools-inc-dir', type='string', help='Path to CUTOOLS includes', dest='cutoolsIncDir')
-    opt.add_option('--cutools-lib-dir', type='string', help='Path to CUTOOLS libraries', dest='cutoolsLibDir')
-    opt.add_option('--cutools-link-libs', type='string', help='List of CUTOOLS libraries to link',
-                   dest='cutoolsLinkLibs', default='cutools')
+    opt.add_option('--cuda-inc-dir', type='string', help='Path to CUTOOLS includes', dest='cuIncDir')
+    opt.add_option('--cuda-lib-dir', type='string', help='Path to CUTOOLS libraries', dest='cuLibDir')
+    opt.add_option('--cuda-link-libs', type='string', help='List of CUTOOLS libraries to link',
+                   dest='cuLinkLibs', default='cudart')
 
 @conf
 def check_cutools(conf):
     opt = conf.options
     conf.env['CUTOOLS_FOUND'] = False
     
-    if conf.options.cutoolsIncDir:
-        conf.env.INCLUDES_CUTOOLS = conf.options.cutoolsIncDir
+    if conf.options.cuIncDir:
+        conf.env.INCLUDES_CUTOOLS = conf.options.cuIncDir.split(":")
 
-    if conf.options.cutoolsLibDir:
-        conf.env.LIBPATH_CUTOOLS = conf.options.cutoolsLibDir
+    if conf.options.cuLibDir:
+        conf.env.LIBPATH_CUTOOLS = conf.options.cuLibDir.split(":")
 
-    libList = conf.options.cutoolsLinkLibs
+    libList = conf.options.cuLinkLibs
     conf.env.LIB_CUTOOLS = libList.split(',')
     
     conf.start_msg('Checking for NVCC compiler')
     try:
-        conf.find_program('nvcc', var='nvcc', mandatory=True)
+        conf.find_program('nvcc', var='NVCC', mandatory=True)
         conf.end_msg("Found NVCC")
+        conf.check(header_name='cuda.h', features='cxx cxxprogram', use="CUTOOLS", mandatory=True)
+        conf.check(header_name='cuda_runtime.h', features='cxx cxxprogram', use="CUTOOLS", mandatory=True)
+        conf.end_msg("Linking to libraries work")
         conf.env['CUTOOLS_FOUND'] = True
     except:
         conf.end_msg("Not found NVCC", "YELLOW")

--- a/waf_tools/cutools.py
+++ b/waf_tools/cutools.py
@@ -1,0 +1,36 @@
+"""
+Detect CUDA compiler, includes and libraries.
+"""
+
+import os, glob, types
+from waflib.Configure import conf
+
+def options(opt):
+    opt.add_option('--cutools-inc-dir', type='string', help='Path to CUTOOLS includes', dest='cutoolsIncDir')
+    opt.add_option('--cutools-lib-dir', type='string', help='Path to CUTOOLS libraries', dest='cutoolsLibDir')
+    opt.add_option('--cutools-link-libs', type='string', help='List of CUTOOLS libraries to link',
+                   dest='cutoolsLinkLibs', default='cutools')
+
+@conf
+def check_cutools(conf):
+    opt = conf.options
+    conf.env['CUTOOLS_FOUND'] = False
+    
+    if conf.options.cutoolsIncDir:
+        conf.env.INCLUDES_CUTOOLS = conf.options.cutoolsIncDir
+
+    if conf.options.cutoolsLibDir:
+        conf.env.LIBPATH_CUTOOLS = conf.options.cutoolsLibDir
+
+    libList = conf.options.cutoolsLinkLibs
+    conf.env.LIB_CUTOOLS = libList.split(',')
+    
+    conf.start_msg('Checking for NVCC compiler')
+    conf.find_program('nvcc', va='nvcc')
+    conf.end_msg("Found NVCC")
+
+    conf.env['CUTOOLS_FOUND'] = True
+    return 1
+
+def detect(conf):
+    return detect_cutools(conf)

--- a/waf_tools/cutools.py
+++ b/waf_tools/cutools.py
@@ -26,10 +26,14 @@ def check_cutools(conf):
     conf.env.LIB_CUTOOLS = libList.split(',')
     
     conf.start_msg('Checking for NVCC compiler')
-    conf.find_program('nvcc', va='nvcc')
-    conf.end_msg("Found NVCC")
-
-    conf.env['CUTOOLS_FOUND'] = True
+    try:
+        conf.find_program('nvcc', var='nvcc', mandatory=True)
+        conf.end_msg("Found NVCC")
+        conf.env['CUTOOLS_FOUND'] = True
+    except:
+        conf.end_msg("Not found NVCC", "YELLOW")
+        conf.env['CUTOOLS_FOUND'] = False
+        
     return 1
 
 def detect(conf):

--- a/wscript
+++ b/wscript
@@ -229,6 +229,9 @@ def buildExec(bld):
     useList = 'lib datastruct eq unit comm updater proto basis grid LUAJIT ADIOS EIGEN MPI M DL'
     if bld.env['USE_SQLITE']:
         useList = 'sqlite3 ' + useList
+    if bld.env['CUTOOLS_FOUND']:
+        useList = 'CUTOOLS ' + useList
+    print(useList)
 
     # set RPATH
     fullRpath = []

--- a/wscript
+++ b/wscript
@@ -178,6 +178,13 @@ def build(bld):
         App_dir.ant_glob('**/*.lua'),
         cwd=App_dir, relative_trick=True)
 
+    # - Cuda
+    Cuda_dir = bld.path.find_dir('Cuda')
+    bld.install_files(
+        "${PREFIX}/bin/Cuda",
+        Cuda_dir.ant_glob('**/*.lua'),
+        cwd=Cuda_dir, relative_trick=True)
+
     # - Comm
     Comm_dir = bld.path.find_dir('Comm')
     bld.install_files(

--- a/wscript
+++ b/wscript
@@ -22,7 +22,7 @@ EXTRA_LINK_FLAGS = []
 
 def options(opt):
     opt.load('compiler_c compiler_cxx') 
-    opt.load('gkyl luajit mpi adios eigen sqlite3',
+    opt.load('gkyl luajit mpi adios eigen sqlite3 cutools',
              tooldir='waf_tools')
 
 def configure(conf):
@@ -36,6 +36,7 @@ def configure(conf):
     conf.check_adios()
     conf.check_eigen()
     conf.check_sqlite3()
+    conf.check_cutools()
 
     # standard install location for dependencies
     gkydepsDir = os.path.expandvars('$HOME/gkylsoft')

--- a/wscript
+++ b/wscript
@@ -231,7 +231,6 @@ def buildExec(bld):
         useList = 'sqlite3 ' + useList
     if bld.env['CUTOOLS_FOUND']:
         useList = 'CUTOOLS ' + useList
-    print(useList)
 
     # set RPATH
     fullRpath = []


### PR DESCRIPTION
This merge brings in search for CUDA on Adroit and adds a unit test (test_Cuda) that at present only finds the runtime-version of the CUDA env installed on the machine. This may appear like a minor thing but is a "big deal" as it is the very first Lua drive CUDA runtime call in Gkeyll!