### PR TITLE
Discont poisson aux funcs

### DIFF
--- a/Gkyl.h
+++ b/Gkyl.h
@@ -35,6 +35,10 @@
 #include <Eigen/Core>
 #endif
 
+#ifdef HAVE_SPECTRA_H
+#include <Spectra/GenEigsSolver.h>
+#endif
+
 #ifdef HAVE_ZMQ_H
 #include <zmq.h>
 #endif
@@ -229,6 +233,12 @@ std::string Gkyl::createTopLevelDefs() const {
   varDefs << "GKYL_HAVE_EIGEN = true" << std::endl;
 #else
   varDefs << "GKYL_HAVE_EIGEN = false" << std::endl;
+#endif
+
+#ifdef HAVE_SPECTRA_H
+  varDefs << "GKYL_HAVE_SPECTRA = true" << std::endl;
+#else
+  varDefs << "GKYL_HAVE_SPECTRA = false" << std::endl;
 #endif
 
 #ifdef HAVE_ZMQ_H

--- a/Updater/DiscontPoisson.lua
+++ b/Updater/DiscontPoisson.lua
@@ -30,6 +30,8 @@ ffi.cdef[[
   void discontPoisson_pushSource(DiscontPoisson* f, int idx, double* src, double* srcMod);
   void discontPoisson_solve(DiscontPoisson* f);
   void discontPoisson_getSolution(DiscontPoisson* f, int idx, double* sol);
+
+  void discontPoisson_getEigenvalues(DiscontPoisson* f);
 ]]
 
 -- DG Poisson solver updater object.

--- a/Updater/DiscontPoisson.lua
+++ b/Updater/DiscontPoisson.lua
@@ -270,6 +270,11 @@ function DiscontPoisson:_advance(tCurr, inFld, outFld)
    self._first = false
 end
 
+-- Additional methods to evaluate eigenvalues needed by multigrid solver.
+function DiscontPoisson:calcEigenvalues()
+   ffiC.discontPoisson_getEigenvalues(self.poisson)
+end
+
 function DiscontPoisson:delete()
   ffiC.delete_DiscontPoisson(self.poisson)
 end

--- a/Updater/DiscontPoisson.lua
+++ b/Updater/DiscontPoisson.lua
@@ -1,21 +1,24 @@
 -- Gkyl ------------------------------------------------------------------------
 --
--- Updater to solve Poisson equation in perpendicular directions with FEM scheme
--- Perpendicular directions assumed to be first two configuration-space directions
+-- Updater to (directly) solve Poisson equation 
+--
+--      - Laplacian(phi) = rho
+--
+-- in 1D, 2D or 3D with RDG discretization.
 --
 --    _______     ___
 -- + 6 @ |||| # P ||| +
 --------------------------------------------------------------------------------
 
--- Gkyl libraries
+-- Gkyl libraries.
 local CartFieldIntegratedQuantCalc = require "Updater.CartFieldIntegratedQuantCalc"
-local Lin = require "Lib.Linalg"
-local Proto = require "Lib.Proto"
-local Range = require "Lib.Range"
-local UpdaterBase = require "Updater.Base"
-local ffi = require "ffi"
-local ffiC = ffi.C
-local xsys = require "xsys"
+local Lin                          = require "Lib.Linalg"
+local Proto                        = require "Lib.Proto"
+local Range                        = require "Lib.Range"
+local UpdaterBase                  = require "Updater.Base"
+local ffi                          = require "ffi"
+local ffiC                         = ffi.C
+local xsys                         = require "xsys"
 
 ffi.cdef[[
   typedef struct DiscontPoisson DiscontPoisson;
@@ -29,27 +32,26 @@ ffi.cdef[[
   void discontPoisson_getSolution(DiscontPoisson* f, int idx, double* sol);
 ]]
 
--- FEM Poisson solver updater object
+-- DG Poisson solver updater object.
 local DiscontPoisson = Proto(UpdaterBase)
 
 function DiscontPoisson:init(tbl)
    DiscontPoisson.super.init(self, tbl)
 
-   -- read data from input file
-   self.grid = assert(tbl.onGrid, "Updater.DiscontPoisson: Must provide grid object using 'onGrid'")
+   self.grid  = assert(tbl.onGrid, "Updater.DiscontPoisson: Must provide grid object using 'onGrid'")
    self.basis = assert(tbl.basis, "Updater.DiscontPoisson: Must specify basis functions to use using 'basis'")
 
    assert(self.basis:id() == "serendipity", "Updater.DiscontPoisson only implemented for modal serendipity basis")
 
    assert(self.grid:ndim() == self.basis:ndim(), "Dimensions of basis and grid must match")
-   self.ndim = self.grid:ndim()
-   self.nbasis = self.basis:numBasis()
+   self.ndim       = self.grid:ndim()
+   self.nbasis     = self.basis:numBasis()
    local polyOrder = self.basis:polyOrder()
-   self.ncell = ffi.new("int[3]")
-   local dx = Lin.Vec(3)
+   self.ncell      = ffi.new("int[3]")
+   local dx        = Lin.Vec(3)
    for d = 1,self.ndim do
       self.ncell[d-1] = self.grid:numCells(d)
-      dx[d] = self.grid:dx(d)
+      dx[d]           = self.grid:dx(d)
    end
 
    local writeMatrix = xsys.pickBool(tbl.writeMatrix, false)
@@ -84,7 +86,7 @@ function DiscontPoisson:init(tbl)
    end
 
    self._first = true
-   local dirs = {'x','y','z'}
+   local dirs  = {'x','y','z'}
    self.stencilMatrix = {}
    self.stencilMatrixLo, self.stencilMatrixUp = {}, {}
    for d = 1, self.ndim do
@@ -116,17 +118,12 @@ function DiscontPoisson:init(tbl)
    return self
 end
 
----- advance method
-function DiscontPoisson:_advance(tCurr, inFld, outFld)
-   local grid = self.grid
-   local basis = self.basis
-   local ndim = self.ndim
+function DiscontPoisson:buildStiffMatrix(phi)
+   -- Assemble the left-side matrix of the Poisson equation.
 
-   local src = assert(inFld[1], "DiscontPoisson.advance: Must specify an input field")
-   local sol = assert(outFld[1], "DiscontPoisson.advance: Must specify an output field")
+   local ndim         = self.ndim
 
-   --local globalRange = src:globalRange()
-   local localRange = src:localRange()
+   local localRange   = phi:localRange()
    local lower, upper = {}, {}
    for d = 1,ndim do
       lower[d] = localRange:lower(d)
@@ -134,89 +131,111 @@ function DiscontPoisson:_advance(tCurr, inFld, outFld)
    end
    lower[ndim+1] = 1
    upper[ndim+1] = self.nbasis
-   local stiffMatrixRange = Range.Range(lower, upper)
+   local stiffMatrixRange   = Range.Range(lower, upper)
    local stiffMatrixIndexer = Range.makeRowMajorGenIndexer(stiffMatrixRange)
 
-   -- construct the stiffness matrix using Eigen
+   local idxsExtK, idxsExtL = Lin.Vec(ndim+1), Lin.Vec(ndim+1)
+   local cnt, val           = 1, 0.0
+   local idxK, idxL         = 0, 0
+
+   for idxs in localRange:colMajorIter() do
+      for d = 1,ndim do
+         idxsExtK[d] = idxs[d]
+         idxsExtL[d] = idxs[d]
+      end
+      for k = 1,self.nbasis do
+         idxsExtK[ndim+1] = k
+         idxK = stiffMatrixIndexer(idxsExtK)
+         for l = 1,self.basis:numBasis() do
+            idxsExtL[ndim+1] = l
+            idxL             = stiffMatrixIndexer(idxsExtL)
+            
+            -- Diagonal blocks
+            val = 0.0
+            for d = 1,ndim do
+               if idxs[d] == localRange:lower(d) then
+                  val = val + self.stencilMatrixLo[d][2][k][l]
+               elseif idxs[d] == localRange:upper(d) then
+                  val = val + self.stencilMatrixUp[d][2][k][l]
+               else
+                  val = val + self.stencilMatrix[d][2][k][l]
+               end
+            end
+            if val ~= 0 then
+               ffiC.discontPoisson_pushTriplet(self.poisson, idxK-1, idxL-1, val)
+            end
+
+            -- Off-diagonal blocks                              
+            for d = 1,ndim do
+               if idxs[d] == localRange:lower(d) then
+                  idxsExtL[d] = idxsExtL[d]+1
+                  idxL        = stiffMatrixIndexer(idxsExtL)
+                  val         = self.stencilMatrixLo[d][3][k][l]
+                  if val ~= 0 then
+                     ffiC.discontPoisson_pushTriplet(self.poisson, idxK-1, idxL-1, val)
+                  end
+                  idxsExtL[d] = idxsExtL[d]-1
+               elseif idxs[d] == localRange:upper(d) then
+                  idxsExtL[d] = idxsExtL[d]-1
+                  idxL        = stiffMatrixIndexer(idxsExtL)
+                  val         = self.stencilMatrixUp[d][1][k][l]
+                  if val ~= 0 then
+                     ffiC.discontPoisson_pushTriplet(self.poisson, idxK-1, idxL-1, val)
+                  end
+                  idxsExtL[d] = idxsExtL[d]+1
+               else
+                  idxsExtL[d] = idxsExtL[d]-1
+                  idxL        = stiffMatrixIndexer(idxsExtL)
+                  val         = self.stencilMatrix[d][1][k][l]
+                  if val ~= 0 then
+                     ffiC.discontPoisson_pushTriplet(self.poisson, idxK-1, idxL-1, val)
+                  end
+                  idxsExtL[d] = idxsExtL[d]+1
+                  
+                  idxsExtL[d] = idxsExtL[d]+1
+                  idxL        = stiffMatrixIndexer(idxsExtL)
+                  val         = self.stencilMatrix[d][3][k][l]
+                  if val ~= 0 then
+                     ffiC.discontPoisson_pushTriplet(self.poisson, idxK-1, idxL-1, val)
+                  end
+                  idxsExtL[d] = idxsExtL[d]-1
+               end
+            end               
+         end
+      end
+   end
+   ffiC.discontPoisson_constructStiffMatrix(self.poisson);
+end
+
+-- Advance method.
+function DiscontPoisson:_advance(tCurr, inFld, outFld)
+   local ndim  = self.ndim
+
+   local src = assert(inFld[1], "DiscontPoisson.advance: Must specify an input field")
+   local sol = assert(outFld[1], "DiscontPoisson.advance: Must specify an output field")
+
+   local localRange   = src:localRange()
+   local lower, upper = {}, {}
+   for d = 1,ndim do
+      lower[d] = localRange:lower(d)
+      upper[d] = localRange:upper(d)
+   end
+   lower[ndim+1] = 1
+   upper[ndim+1] = self.nbasis
+   local stiffMatrixRange   = Range.Range(lower, upper)
+   local stiffMatrixIndexer = Range.makeRowMajorGenIndexer(stiffMatrixRange)
+
    if self._first then
       self.srcIndexer = src:genIndexer()
       self.solIndexer = sol:genIndexer()
-      local idxsExtK, idxsExtL = Lin.Vec(ndim+1), Lin.Vec(ndim+1)
-      local cnt, val = 1, 0.0
-      local idxK, idxL = 0, 0
 
-      for idxs in localRange:colMajorIter() do
-         for d = 1,ndim do
-            idxsExtK[d] = idxs[d]
-            idxsExtL[d] = idxs[d]
-         end
-         for k = 1,self.nbasis do
-            idxsExtK[ndim+1] = k
-            idxK = stiffMatrixIndexer(idxsExtK)
-            for l = 1,basis:numBasis() do
-               idxsExtL[ndim+1] = l
-               idxL = stiffMatrixIndexer(idxsExtL)
-               
-               -- Diagonal blocks
-               val = 0.0
-               for d = 1,ndim do
-                  if idxs[d] == localRange:lower(d) then
-                     val = val + self.stencilMatrixLo[d][2][k][l]
-                  elseif idxs[d] == localRange:upper(d) then
-                     val = val + self.stencilMatrixUp[d][2][k][l]
-                  else
-                     val = val + self.stencilMatrix[d][2][k][l]
-                  end
-               end
-               if val ~= 0 then
-                  ffiC.discontPoisson_pushTriplet(self.poisson, idxK-1, idxL-1, val)
-               end
-
-               -- Off-diagonal blocks                              
-               for d = 1,ndim do
-                  if idxs[d] == localRange:lower(d) then
-                     idxsExtL[d] = idxsExtL[d]+1
-                     idxL = stiffMatrixIndexer(idxsExtL)
-                     val = self.stencilMatrixLo[d][3][k][l]
-                     if val ~= 0 then
-                        ffiC.discontPoisson_pushTriplet(self.poisson, idxK-1, idxL-1, val)
-                     end
-                     idxsExtL[d] = idxsExtL[d]-1
-                  elseif idxs[d] == localRange:upper(d) then
-                     idxsExtL[d] = idxsExtL[d]-1
-                     idxL = stiffMatrixIndexer(idxsExtL)
-                     val = self.stencilMatrixUp[d][1][k][l]
-                     if val ~= 0 then
-                        ffiC.discontPoisson_pushTriplet(self.poisson, idxK-1, idxL-1, val)
-                     end
-                     idxsExtL[d] = idxsExtL[d]+1
-                  else
-                     idxsExtL[d] = idxsExtL[d]-1
-                     idxL = stiffMatrixIndexer(idxsExtL)
-                     val = self.stencilMatrix[d][1][k][l]
-                     if val ~= 0 then
-                        ffiC.discontPoisson_pushTriplet(self.poisson, idxK-1, idxL-1, val)
-                     end
-                     idxsExtL[d] = idxsExtL[d]+1
-                     
-                     idxsExtL[d] = idxsExtL[d]+1
-                     idxL = stiffMatrixIndexer(idxsExtL)
-                     val = self.stencilMatrix[d][3][k][l]
-                     if val ~= 0 then
-                        ffiC.discontPoisson_pushTriplet(self.poisson, idxK-1, idxL-1, val)
-                     end
-                     idxsExtL[d] = idxsExtL[d]-1
-                  end
-               end               
-            end
-         end
-      end
-      ffiC.discontPoisson_constructStiffMatrix(self.poisson);
+      -- Construct the stiffness matrix using Eigen.
+      self:buildStiffMatrix(sol)
    end
 
-   -- Pushing source to the Eigen matrix
+   -- Pushing source to the Eigen matrix.
    local idxsExt = Lin.Vec(ndim+1)
-   local srcMod = Lin.Vec(self.nbasis)
+   local srcMod  = Lin.Vec(self.nbasis)
    for idxs in localRange:colMajorIter() do
       for k = 1,self.nbasis do srcMod[k] = 0.0 end
       for d = 1,ndim do
@@ -238,7 +257,7 @@ function DiscontPoisson:_advance(tCurr, inFld, outFld)
    ffiC.discontPoisson_solve(self.poisson)
 
    for idxs in localRange:colMajorIter() do
-      local solPtr = sol:get(self.solIndexer(idxs))
+      local solPtr  = sol:get(self.solIndexer(idxs))
       local idxsExt = Lin.Vec(ndim+1)
       for d = 1,ndim do idxsExt[d] = idxs[d] end
       idxsExt[ndim+1] = 1

--- a/Updater/DiscontPoissonImpl.cpp
+++ b/Updater/DiscontPoissonImpl.cpp
@@ -81,12 +81,21 @@ void DiscontPoisson::solve() {
 // Below are some auxiliary functions to probe properties of the
 // left-side matrix, and iteration matrices used by multigrid solver.
 void DiscontPoisson::getEigenvalues() {
-//  VectorXcd eiVals = stiffMatRowMajor.eigenvalues();
-//  EigenSolver<MatrixXd> es(stiffMatRowMajor,false);
-  MatrixXd Atmp = MatrixXd::Random(6,6);
-  EigenSolver<MatrixXd> es(Atmp,false);
-  VectorXcd eiVals = es.eigenvalues();
-//  saveMarketVector(eiVals, "DiscontPoisson_Aeigenvalues.mtx");
+
+  // Construct matrix operation object using wrapper class SparseGenMatProd.
+  SparseGenMatProd<double> op(stiffMat);
+  // Construct eigen solver object, requesting the largest three eigenvalues
+  GenEigsSolver< double, LARGEST_MAGN, SparseGenMatProd<double> > eigs(&op, 3, 6);
+  // Initialize and compute
+  eigs.init();
+  int nconv = eigs.compute();
+  // Retrieve results
+  Eigen::VectorXcd eiValues;
+  if (eigs.info() == SUCCESSFUL)
+    eiValues = eigs.eigenvalues();
+
+  std::cout << "Three largest eigenvalues found:\n" << eiValues << std::endl;
+
 }
 
 

--- a/Updater/DiscontPoissonImpl.cpp
+++ b/Updater/DiscontPoissonImpl.cpp
@@ -1,6 +1,6 @@
 // Gkyl ------------------------------------------------------------------------
 //
-// C++ back-end for 2D discontinuous Poisson solver
+// C++ back-end for discontinuous Poisson direct solver: -Laplacian(phi) = rho.
 //    _______     ___
 // + 6 @ |||| # P ||| +
 //------------------------------------------------------------------------------
@@ -78,8 +78,19 @@ void DiscontPoisson::solve() {
   //saveMarket(x, "solution");
 }
 
+// Below are some auxiliary functions to probe properties of the
+// left-side matrix, and iteration matrices used by multigrid solver.
+void DiscontPoisson::getEigenvalues() {
+//  VectorXcd eiVals = stiffMatRowMajor.eigenvalues();
+//  EigenSolver<MatrixXd> es(stiffMatRowMajor,false);
+  MatrixXd Atmp = MatrixXd::Random(6,6);
+  EigenSolver<MatrixXd> es(Atmp,false);
+  VectorXcd eiVals = es.eigenvalues();
+//  saveMarketVector(eiVals, "DiscontPoisson_Aeigenvalues.mtx");
+}
 
-// C wrappers for interfacing with DiscontPoisson class
+
+// C wrappers for interfacing with DiscontPoisson class.
 extern "C" void* new_DiscontPoisson(int ncell[3], int ndim, int nbasis,
                                     int nnonzero, int polyOrder, bool writeMatrix)
 {
@@ -116,4 +127,9 @@ extern "C" void discontPoisson_pushSource(DiscontPoisson* f, int idx, double* sr
 extern "C" void discontPoisson_getSolution(DiscontPoisson* f, int idx, double* sol)
 {
   f->getSolution(idx, sol);
+}
+
+extern "C" void discontPoisson_getEigenvalues(DiscontPoisson* f)
+{
+  f->getEigenvalues();
 }

--- a/Updater/DiscontPoissonImpl.h
+++ b/Updater/DiscontPoissonImpl.h
@@ -1,6 +1,6 @@
 // Gkyl ------------------------------------------------------------------------
 //
-// C++ back-end for 2D FEM Poisson solver
+// C++ back-end for discontinuous Poisson direct solver: -Laplacian(phi) = rho.
 //    _______     ___
 // + 6 @ |||| # P ||| +
 //------------------------------------------------------------------------------
@@ -18,8 +18,13 @@
 #include <Eigen/SparseQR>
 #include <Eigen/IterativeLinearSolvers>
 #include <unsupported/Eigen/SparseExtra>
+#include <Eigen/SparseCore>
+#include <Spectra/GenEigsSolver.h>
+#include <Spectra/MatOp/SparseGenMatProd.h>
 
 #include <mpi.h>
+
+using namespace Spectra;
 
 class DiscontPoisson;
 
@@ -34,6 +39,8 @@ extern "C" {
   void discontPoisson_pushSource(DiscontPoisson* f, int idx, double* src, double* srcMod);
   void discontPoisson_getSolution(DiscontPoisson* f, int idx, double* sol);
   void discontPoisson_solve(DiscontPoisson* f);
+  // Auxiliary functions for analyzing the left-side matrix.
+  void discontPoisson_getEigenvalues(DiscontPoisson* f);
 }
 
 class DiscontPoisson
@@ -49,6 +56,8 @@ class DiscontPoisson
   void pushSource(int idx, double* src, double* srcMod);
   void getSolution(int idx, double* sol);
   void solve();
+
+  void getEigenvalues();
   
  private:
   const int ndim, polyOrder, nbasis, nnonzero;

--- a/Updater/wscript
+++ b/Updater/wscript
@@ -221,5 +221,5 @@ def build(bld):
         )
 
     bld.shlib(source = sources,
-              includes = '. .. ../Cuda mgPoissonCalcData spitzerNuCalcData primMomentsCalcData binOpCalcData lagrangeFixData momentCalcData confToPhaseData', use='lib EIGEN MPI', target = 'updater', name = 'updater', vum = '1.0')
+              includes = '. .. ../Cuda mgPoissonCalcData spitzerNuCalcData primMomentsCalcData binOpCalcData lagrangeFixData momentCalcData confToPhaseData', use='lib EIGEN SPECTRA MPI', target = 'updater', name = 'updater', vum = '1.0')
     

--- a/gkyl.cxx
+++ b/gkyl.cxx
@@ -105,6 +105,9 @@ void showVersion() {
 #ifdef HAVE_EIGEN_CORE
   std::cout << " Eigen";
 #endif
+#ifdef HAVE_SPECTRA_H
+  std::cout << " Spectra";
+#endif
 #ifdef USING_SQLITE3
   std::cout << " Sqlite3";
 #endif    

--- a/install-deps/build-spectra.sh
+++ b/install-deps/build-spectra.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+source ./build-opts.sh
+
+# Install prefix
+PREFIX=$GKYLSOFT/spectra
+
+# delete old checkout and builds
+rm -rf spectra.tar* spectra-master.tar*
+
+curl -L https://github.com/yixuan/spectra/tarball/master > spectra-master.tar.gz
+gunzip spectra-master.tar.gz
+tar -xvf spectra-master.tar
+
+mv yixuan-spectra-* $PREFIX
+
+rm -rf spectra-master.tar* 
+
+# softlink to make finding easier
+ln -sf $PREFIX $GKYLSOFT/spectra
+

--- a/install-deps/mkdeps.sh
+++ b/install-deps/mkdeps.sh
@@ -18,6 +18,7 @@ BUILD_LUAROCKS=
 BUILD_ADIOS=
 BUILD_OPENMPI=
 BUILD_EIGEN=
+BUILD_SPECTRA=
 BUILD_ZMQ=
 BUILD_CZMQ=
 
@@ -57,6 +58,7 @@ and C++ compilers to use.
 --build-adios               Should we build ADIOS?
 --build-openmpi             Should we build OpenMPI?
 --build-eigen               Should we build Eigen?
+--build-spectra             Should we build Spectra?
 --build-zmq                 Should we build ZeroMQ?
 --build-czmq                Should we build C interface to ZeroMQ?
 
@@ -139,6 +141,10 @@ do
       [ -n "$value" ] || die "Missing value in flag $key."
       BUILD_EIGEN="$value"
       ;;
+   --build-spectra)
+      [ -n "$value" ] || die "Missing value in flag $key."
+      BUILD_SPECTRA="$value"
+      ;;
    --build-luajit)
       [ -n "$value" ] || die "Missing value in flag $key."
       BUILD_LUAJIT="$value"
@@ -216,6 +222,14 @@ build_eigen() {
     fi
 }
 
+build_spectra() {
+    if [[ ! "$BUILD_SPECTRA" = "no" && ("$BUILD_SPECTRA" = "yes" || ! -f $PREFIX/spectra/include/Spectra/GenEigsSolver.h) ]]
+    then
+	echo "Building SPECTRA"
+	./build-spectra.sh
+    fi
+}
+
 build_luajit() {
     if [[ ! "$BUILD_LUAJIT" = "no" && ("$BUILD_LUAJIT" = "yes" || ! -f $PREFIX/luajit/include/luajit-2.1/lua.hpp) ]]
     then    
@@ -281,5 +295,6 @@ build_luajit_ppcle
 build_luarocks
 build_adios
 build_eigen
+build_spectra
 build_zmq
 build_czmq

--- a/waf_tools/spectra.py
+++ b/waf_tools/spectra.py
@@ -1,0 +1,36 @@
+"""
+Detect SPECTRA includes and libraries.
+"""
+
+import os, glob, types
+from waflib.Configure import conf
+
+def options(opt):
+    opt.add_option('--enable-spectra', help=('Enable SPECTRA'),
+                   dest='enable_spectra', action='store_true',
+                   default=True)
+    opt.add_option('--disable-spectra', help=('Disable SPECTRA'),
+                   dest='enable_spectra', action='store_false')
+    opt.add_option('--spectra-inc-dir', type='string', help='Path to SPECTRA includes', dest='spectraIncDir')
+
+@conf
+def check_spectra(conf):
+    opt = conf.options
+    conf.env['SPECTRA_FOUND'] = False
+
+    if not conf.options.enable_spectra:
+        return
+    
+    if conf.options.spectraIncDir:
+        conf.env.INCLUDES_SPECTRA = conf.options.spectraIncDir
+    else:
+        conf.env.INCLUDES_SPECTRA = conf.options.gkylDepsDir+'/spectra/include'
+
+    conf.start_msg('Checking for SPECTRA')
+    conf.check(header_name='Spectra/SymEigsSolver.h', features='cxx cxxprogram', use='SPECTRA', mandatory=False)
+    conf.end_msg("Found SPECTRA")
+    conf.env['SPECTRA_FOUND'] = True
+    return 1
+
+def detect(conf):
+    return detect_spectra(conf)

--- a/wscript
+++ b/wscript
@@ -24,7 +24,7 @@ from waflib import TaskGen
 
 def options(opt):
     opt.load('compiler_c compiler_cxx') 
-    opt.load('gkyl luajit mpi adios eigen sqlite3 cutools',
+    opt.load('gkyl luajit mpi adios eigen sqlite3 cutools spectra',
              tooldir='waf_tools')
 
 def configure(conf):
@@ -38,6 +38,7 @@ def configure(conf):
     conf.check_mpi()
     conf.check_adios()
     conf.check_eigen()
+    conf.check_spectra()
     conf.check_sqlite3()
     conf.check_cutools()
 
@@ -238,7 +239,7 @@ def buildExec(bld):
         bld.env.SHLIB_MARKER = '-Wl,-Bdynamic,--no-as-needed'
 
     # list of objects to use
-    useList = ' lib datastruct eq unit comm updater proto basis grid LUAJIT ADIOS EIGEN MPI M DL '
+    useList = ' lib datastruct eq unit comm updater proto basis grid LUAJIT ADIOS EIGEN SPECTRA MPI M DL '
     if bld.env['USE_SQLITE']:
         useList = 'sqlite3 ' + useList
     if bld.env['CUTOOLS_FOUND']:
@@ -264,4 +265,4 @@ def buildExec(bld):
 
 def dist(ctx):
     ctx.algo = "zip" # use ZIP instead of tar.bz2
-    ctx.excl = " **/.waf* **/*~ **/*.pyc **/*.swp **/.lock-w* configure-par.sh **/.hg **/.hgignore install-deps/build-opts.sh install-deps/luajit-2.0 install-deps/eigen-eigen-* install-deps/adios-1.* install-deps/luarocks-2.4.3* install-deps/openmpi-* build build-par build-ser"
+    ctx.excl = " **/.waf* **/*~ **/*.pyc **/*.swp **/.lock-w* configure-par.sh **/.hg **/.hgignore install-deps/build-opts.sh install-deps/luajit-2.0 install-deps/eigen-eigen-* install-deps/spectra* install-deps/adios-1.* install-deps/luarocks-2.4.3* install-deps/openmpi-* build build-par build-ser"


### PR DESCRIPTION
I'd like to merge this branch into master, but @pcagas and @ammarhakim should check it. This branch does two things:
- Plugs in the Spectra library (an Eigen-based library https://github.com/yixuan/spectra). Otherwise evaluating eigenvalues would require us to take the SparseMatrix that Petr is using and put its contents in a dense matrix, then call .eigenvalues(). But that would be inefficient.
- It adds a function to DiscontPoisson to ask for eigenvalues.

To add Spectra to the gkeyll build go into install-depts, run mkdeps.sh again, then you'll have to reconfigure and do ./waf build install again. TO CONFIGURE: 

Add the following line below the line where EIGEN_INC_DIR is declared in configure-par.sh (or whatever configure script you use):

\# SPECTRA options
SPECTRA_INC_DIR=$HOME/gkylsoft/spectra/include/

And you'll have to change the configure command to (this just appends --spectra-inc-dir=$SPECTRA_INC_DIR):
cmd="./waf --out=$OUT --prefix=$PREFIX --cxxflags=$CXXFLAGS --luajit-inc-dir=$LUAJIT_INC_DIR --luajit-lib-dir=$LUAJIT_LIB_DIR --luajit-share-dir=$LUAJIT_SHARE_DIR  $ENABLE_MPI --mpi-inc-dir=$MPI_INC_DIR --mpi-lib-dir=$MPI_LIB_DIR --mpi-link-libs=$MPI_LINK_LIBS $ENABLE_ADIOS --adios-inc-dir=$ADIOS_INC_DIR --adios-lib-dir=$ADIOS_LIB_DIR --eigen-inc-dir=$EIGEN_INC_DIR --spectra-inc-dir=$SPECTRA_INC_DIR configure"

I didn't want to edit the configure file checked in before you guys approve this.