### PR TITLE
New DynVector methods

### DIFF
--- a/Lib/Alloc.lua
+++ b/Lib/Alloc.lua
@@ -153,6 +153,13 @@ local function Alloc_meta_ctor(elct)
 	 function (self)
 	    return self._data[self._size-1]
 	 end,
+      assignLast = copyElemFunc and
+	 function (self, v)
+	    copyElemFunc(self._data[self._size-1], v)
+	 end or
+	 function (self, v)
+	    self._data[self._size-1] = v
+	 end,
       popLast = function(self)
 	 assert(self._size > 0, "Can't pop from empty Alloc array")
 	 local l = self:last()

--- a/Unit/test_Alloc.lua
+++ b/Unit/test_Alloc.lua
@@ -118,6 +118,9 @@ function test_4()
       assert_equal(i, da[i], "Testing post-push")
    end
 
+   da:assignLast(2.2)
+   assert_equal(2.2, da:last(), "Testing size")
+
    da:clear()
    assert_equal(0, da:size(), "Testing size")
 end

--- a/Unit/test_DynVector.lua
+++ b/Unit/test_DynVector.lua
@@ -105,10 +105,70 @@ function test_3()
    assert_equal(lv[2], 2.5*9^2+0.5, "Testing last value")
 end
 
+function test_4()
+   local dynVec = DataStruct.DynVector { numComponents = 2 }
+   dynVec:appendData(0.1, {2.5, 3.5})
+
+   local tm, lv = dynVec:lastData()
+   assert_equal(0.1, tm, "Testing last time")
+   assert_equal(2.5, lv[1], "Testing last value")
+   assert_equal(3.5, lv[2], "Testing last value")
+
+   dynVec:assignLastVal(2, {1.75, 1.25})
+   tm, lv = dynVec:lastData()
+   assert_equal(0.1, tm, "Testing last time")
+   assert_equal(3.5, lv[1], "Testing last value after assignLastVal")
+   assert_equal(2.5, lv[2], "Testing last value after assignLastVal")
+
+   local dummyVec = DataStruct.DynVector { numComponents = 2 }
+   dummyVec:appendData(0.1, {7.5, 4.5})
+
+   for i = 2, 10 do
+      dynVec:appendData(0.1*i, {2.5+i, 3.5+i})
+   end
+   dynVec:copyLast(dummyVec)
+   tm, lv = dynVec:lastData()
+   assert_equal(1.0, tm, "Testing last time")
+   assert_equal(7.5, lv[1], "Testing last value after copyLast")
+   assert_equal(4.5, lv[2], "Testing last value after copyLast")
+
+   for i = 11, 20 do
+      dynVec:appendData(0.1*i, {2.5+i, 3.5+i})
+   end
+   dynVec:accumulateLastOne(2.0,dummyVec)
+   tm, lv = dynVec:lastData()
+   assert_equal(2.0, tm, "Testing last time")
+   assert_equal(22.5+7.5*2, lv[1], "Testing last value after accumulateLastOne")
+   assert_equal(23.5+4.5*2, lv[2], "Testing last value after accumulateLastOne")
+
+   dynVec:assignLast(0.2, dummyVec)
+   tm, lv = dynVec:lastData()
+   assert_equal(2.0, tm, "Testing last time")
+   assert_equal(7.5*0.2, lv[1], "Testing last value after assignLast")
+   assert_equal(4.5*0.2, lv[2], "Testing last value after assignLast")
+
+   dynVec:combineLast(1.0, dummyVec, 2.0, dummyVec)
+   tm, lv = dynVec:lastData()
+   assert_equal(2.0, tm, "Testing last time")
+   assert_equal(7.5*3.0, lv[1], "Testing last value after combineLast")
+   assert_equal(4.5*3.0, lv[2], "Testing last value after combineLast")
+
+   dynVec:accumulateLast(1.0, dummyVec, 2.0, dummyVec)
+   tm, lv = dynVec:lastData()
+   assert_equal(2.0, tm, "Testing last time")
+   assert_equal(7.5*6.0, lv[1], "Testing last value after accumulateLast")
+   assert_equal(4.5*6.0, lv[2], "Testing last value after accumulateLast")
+
+   dynVec:assignLastTime(3.0)
+   tm, lv = dynVec:lastData()
+   assert_equal(3.0, tm, "Testing last time after assignLastTime")
+end
+
 test_1()
 test_2()
 test_2r()
 test_3()
+test_4()
 
 totalFail = allReduceOneInt(stats.fail)
 totalPass = allReduceOneInt(stats.pass)


### PR DESCRIPTION
I'm submitting a pull request so that AH (or others) can comment on/approve the choice of methods implemented. I mimiced some of those in CartField (e.g. combine, accumulate, etc), but added the suffix 'Last', to indicate that they act on the last entry of the DynVector (e.g. combineLast, accumulateLast, etc).

Below is the commit message from the last commit:

Add new DynVector methods, and unit tests for these methods. I also wrote a simple Predator-Prey solver with DynVectors using these methods; tested it by solving the SIR model and reproduced a plot on IDM's EMOD website (the one on SIR and SIRS models).