### PR TITLE
Adios group name change for CartField IO

### DIFF
--- a/Io/AdiosCartFieldIo.lua
+++ b/Io/AdiosCartFieldIo.lua
@@ -172,7 +172,7 @@ function AdiosCartFieldIo:write(field, fName, tmStamp, frNum, writeSkin)
    self._outBuff:expand(localRange:volume()*field:numComponents())
 
    -- Get group name based on size (number of cells in each dim and num components).
-   local grpNm = "CartField"..adGlobalSz
+   local grpNm = "CartField"..string.sub(fName,1,string.find(fName,'_')-1)..adGlobalSz
 
    -- Setup group and set I/O method. Only need to do once for each grpNm.
    if not self.grpIds[grpNm] then


### PR DESCRIPTION
Recent changes make it so that when species had the same number of cells, the same attribute values (e.g. for lower/upper bounds) were written in files of different species, even if these had different values for the species.

so: if you run a simulation were electrons and ions have the same number of cells, but different velocity limits, the attributes lowerBounds/upperBounds in the electron and ion files had the same values.

IMPORTANT: did unit/regression tests not catch this? perhaps we should check whether unit/regression tests are checking attribute values.

This commit changes the Adios group name so that the above doesn't happen.