### PR TITLE
cuda_source5m time-centered source update using cuBLAS

### DIFF
--- a/Unit/test_FiveMomentSrcDevice.lua
+++ b/Unit/test_FiveMomentSrcDevice.lua
@@ -1,0 +1,227 @@
+-- Gkyl ------------------------------------------------------------------------
+--
+-- Test for the gpu implementation of the time-centered five-moment source
+-- updater against the cpu implementation.
+--    _______     ___
+-- + 6 @ |||| # P ||| +
+--------------------------------------------------------------------------------
+
+local cuda
+local cuAlloc
+if GKYL_HAVE_CUDA then
+  cuda = require "Cuda.RunTime"
+  cuAlloc = require "Cuda.Alloc"
+end
+
+local Unit = require "Unit"
+local Grid = require "Grid"
+local DataStruct = require "DataStruct"
+local Updater = require "Updater"
+
+local assert_equal = Unit.assert_equal
+local assert_close = Unit.assert_close
+local stats = Unit.stats
+
+local computeMaxFreq = function(charge, mass, rho, Bmag, epsilon0, show)
+   local wp_tot = 0
+   local wc_max = 0
+   for species,_ in ipairs(charge)  do
+      local wp2 = rho[species] * (charge[species] / mass[species])^2 / epsilon0
+      wp_tot = wp_tot + wp2
+      wc_max = math.max(wc_max, math.abs(charge[species] * Bmag / mass[species]))
+   end
+   wp_tot = math.sqrt(wp_tot)
+
+   if show then
+      for species = 1,#charge do
+         print(string.format("species [%d] charge=%g, mass=%g, rho=%g",
+            species, charge[species], mass[species], rho[species]))
+      end
+      print('Bmag=%g, epsilon0=%g')
+
+      print('wp_tot', wp_tot)
+      print('2*pi/wp_tot', 2*math.pi/wp_tot)
+      print('wc_max', wc_max)
+      print('2*pi/wc_max', 2*math.pi/wc_max)
+   end
+
+   return math.max(wp_tot, wc_max)
+end
+
+local grid = Grid.RectCart {
+   lower = {0.0},
+   upper = {1.0},
+   cells = {1},
+}
+
+local fluid1 = DataStruct.Field {
+   onGrid = grid,
+   numComponents = 5,
+}
+local fluid2 = DataStruct.Field {
+   onGrid = grid,
+   numComponents = 5,
+}
+local emf = DataStruct.Field {
+   onGrid = grid,
+   numComponents = 8,
+}
+
+local d_fluid1 = DataStruct.Field {
+   onGrid = grid,
+   numComponents = 5,
+   createDeviceCopy = true,
+}
+local d_fluid2 = DataStruct.Field {
+   onGrid = grid,
+   numComponents = 5,
+   createDeviceCopy = true,
+}
+local d_emf = DataStruct.Field {
+   onGrid = grid,
+   numComponents = 8,
+   createDeviceCopy = true,
+}
+
+local epsilon0 = 1.0
+local gasGamma = 5. / 3.
+
+
+function init(
+   fluid1, fluid2, emf,
+   rho1, rhovx1, rhovy1, rhovz1, p1,
+   rho2, rhovx2, rhovy2, rhovz2, p2,
+   Ex, Ey, Ez, Bx, By, Bz, phiE, phiB
+   )
+
+   local f1Idxr = fluid1:genIndexer()   
+   local f2Idxr = fluid2:genIndexer()   
+   local emIdxr = emf:genIndexer() 
+   for idx in fluid1:localRangeIter() do
+      local f1 = fluid1:get(f1Idxr(idx))
+      local f2 = fluid2:get(f2Idxr(idx))
+      local em = emf:get(emIdxr(idx))
+
+      local e1 = 0.5 * (rhovx1^2 + rhovy1^2 + rhovz1^2) / rho1 + p1 / (gasGamma - 1)
+      f1[1] = rho1
+      f1[2] = rhovx1
+      f1[3] = rhovy1
+      f1[4] = rhovz1
+      f1[5] = e1
+
+      local e2 = 0.5 * (rhovx2^2 + rhovy2^2 + rhovz2^2) / rho2 + p2 / (gasGamma - 1)
+      f2[1] = rho2
+      f2[2] = rhovx2
+      f2[3] = rhovy2
+      f2[4] = rhovz2
+      f2[5] = e2
+
+      em[1] = Ex
+      em[2] = Ey
+      em[3] = Ez
+      em[4] = Bx
+      em[5] = By
+      em[6] = Bz
+      em[7] = phiE
+      em[8] = phiB
+   end
+   fluid1:copyHostToDevice()
+   fluid2:copyHostToDevice()
+   emf:copyHostToDevice()
+
+end
+
+function doTest1(scheme, dtFrac)
+
+   local charge1, mass1, rho1, rhovx1, rhovy1, rhovz1, p1 = -1, 1, 4, 1, 2, 3, 1
+   local charge2, mass2, rho2, rhovx2, rhovy2, rhovz2, p2 = 1, 4, 16, 6, 8, 10, 1.5
+   local Ex, Ey, Ez = 1.2, 1.3, 1.4
+   local Bx, By, Bz = 1, 2, 3
+   local phiE, phiB = 3.33, 4.56
+   local Bmag = math.sqrt(Bx^2 + By^2 + Bz^2)
+
+   local charge = {charge1, charge2}
+   local mass ={mass1, mass2}
+   local rho = {rho1, rho2}
+   local wmax = computeMaxFreq(charge, mass, rho, Bmag, epsilon0)
+   local dt = dtFrac/wmax
+
+   init(
+      fluid1, fluid2, emf,
+      rho1, rhovx1, rhovy1, rhovz1, p1,
+      rho2, rhovx2, rhovy2, rhovz2, p2,
+      Ex, Ey, Ez, Bx, By, Bz, phiE, phiB
+   )
+
+   init(
+      d_fluid1, d_fluid2, d_emf,
+      rho1, rhovx1, rhovy1, rhovz1, p1,
+      rho2, rhovx2, rhovy2, rhovz2, p2,
+      Ex, Ey, Ez, Bx, By, Bz, phiE, phiB
+   )
+   d_fluid1:copyHostToDevice()
+   d_fluid2:copyHostToDevice()
+   d_emf:copyHostToDevice()
+
+   local srcUpdater = Updater.FiveMomentSrc {
+      onGrid = grid,
+      numFluids = #charge,
+      charge = charge,
+      mass = mass,
+      epsilon0 = epsilon0,
+      elcErrorSpeedFactor = 1,
+      mgnErrorSpeedFactor = 1,
+      scheme = scheme,
+   }
+   srcUpdater:setDtAndCflRate(dt, nil)
+
+   srcUpdater:advance(0.0, {}, {fluid1, fluid2, emf})
+
+   srcUpdater:_advanceDevice(0.0, {}, {d_fluid1, d_fluid2, d_emf})
+   d_fluid1:copyDeviceToHost()
+   d_fluid2:copyDeviceToHost()
+   d_emf:copyDeviceToHost()
+
+   local f1Idxr = fluid1:genIndexer()   
+   local f2Idxr = fluid2:genIndexer()   
+   local emIdxr = emf:genIndexer() 
+   local d_f1Idxr = d_fluid1:genIndexer()   
+   local d_f2Idxr = d_fluid2:genIndexer()   
+   local d_emIdxr = d_emf:genIndexer() 
+
+   for idx in fluid1:localRangeIter() do
+      local f1 = fluid1:get(f1Idxr(idx))
+      local d_f1 = d_fluid1:get(d_f1Idxr(idx))
+      for comp = 1,5 do
+         assert_close(f1[comp], d_f1[comp], 1e-10, string.format(
+         "fluid1 index %d component %d is incorrect", f1Idxr(idx), comp))
+      end
+
+      local f2 = fluid1:get(f2Idxr(idx))
+      local d_f2 = d_fluid1:get(d_f2Idxr(idx))
+      for comp = 1,5 do
+         assert_close(f2[comp], d_f2[comp], 1e-10, string.format(
+         "fluid2 index %d component %d is incorrect", f2Idxr(idx), comp))
+      end
+
+      local em = fluid1:get(emIdxr(idx))
+      local d_em = d_fluid1:get(d_emIdxr(idx))
+      for comp = 1,8 do
+         assert_close(em[comp], d_em[comp], 1e-10, string.format(
+         "emf index %d component %d is incorrect", emIdxr(idx), comp))
+      end
+
+   end
+
+end
+
+doTest1("time-centered", 0.1)
+doTest1("direct", 1)
+
+-- TODO Do automatic check.
+if stats.fail > 0 then
+   print(string.format("\nPASSED %d tests", stats.pass))
+   print(string.format("**** FAILED %d tests", stats.fail))
+else
+   print(string.format("PASSED ALL %d tests!", stats.pass))
+end

--- a/Updater/FiveMomentSrc.lua
+++ b/Updater/FiveMomentSrc.lua
@@ -12,11 +12,19 @@ local UpdaterBase = require "Updater.Base"
 local Lin = require "Lib.Linalg"
 local Proto = require "Lib.Proto"
 
+local cuda = nil
+if GKYL_HAVE_CUDA then
+   cuda = require "Cuda.RunTime"
+end
+
 local COL_PIV_HOUSEHOLDER_QR = 0;
 local PARTIAL_PIV_LU = 1;
 
 -- system libraries
 local ffi = require "ffi"
+local xsys = require "xsys"
+local new, copy, fill, sizeof, typeof, metatype = xsys.from(ffi,
+"new, copy, fill, sizeof, typeof, metatype")
 
 -- Define C types for storing private data for use in updater
 ffi.cdef [[
@@ -44,6 +52,11 @@ typedef struct {
   void gkylFiveMomentSrcTimeCenteredDirect(MomentSrcData_t *sd, FluidData_t *fd, double dt, double **f, double *em, double *staticEm, double *sigma, double *auxSrc);
   void gkylFiveMomentSrcTimeCenteredDirect2(MomentSrcData_t *sd, FluidData_t *fd, double dt, double **f, double *em, double *staticEm, double *sigma, double *auxSrc);
   void gkylFiveMomentSrcExact(MomentSrcData_t *sd, FluidData_t *fd, double dt, double **ff, double *em, double *staticEm, double *sigma, double *auxSrc);
+
+  /* CUDA GPU */
+  void momentSrcAdvanceOnDevice(
+    int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
+    double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);
 ]]
 
 -- Explicit, SSP RK3 scheme
@@ -150,11 +163,33 @@ function FiveMomentSrc:init(tbl)
       self._updateSrc = updateSrcTimeCenteredDirect2
    elseif scheme == "exact" then
       self._updateSrc = updateSrcExact
+   else
+      assert(false, string.format("scheme %s not supported", scheme))
+   end
+
+   if GKYL_HAVE_CUDA then
+      self:initDevice()
+      self.numThreads = tbl.numThreads or GKYL_DEFAULT_NUM_THREADS
    end
 end
 
--- advance method
-function FiveMomentSrc:_advance(tCurr, inFld, outFld)
+
+function FiveMomentSrc:initDevice()
+   local sz_sd = sizeof("MomentSrcData_t")
+   self.sd_onDevice, err = cuda.Malloc(sz_sd)
+   cuda.Memcpy(self.sd_onDevice, self._sd, sz_sd, cuda.MemcpyHostToDevice)
+
+   local sz_fd = sizeof("FluidData_t") * self._sd.nFluids
+   self.fd_onDevice, err = cuda.Malloc(sz_fd)
+   cuda.Memcpy(
+      self.fd_onDevice, self._fd, sz_fd , cuda.MemcpyHostToDevice)
+
+   local sz_fluidFlds = sizeof("GkylCartField_t*") * self._sd.nFluids
+   self.d_fluidFlds, err = cuda.Malloc(sz_fluidFlds)
+end
+
+
+function FiveMomentSrc:_advanceDispatch(tCurr, inFld, outFld, target)
    local grid = self._onGrid
    local dt = self._dt
    local nFluids = self._sd.nFluids
@@ -188,40 +223,73 @@ function FiveMomentSrc:_advance(tCurr, inFld, outFld)
       sigmaIdxr = self._sigmaFld:genIndexer()
    end
 
-   -- allocate stuff to pass to C
-   local fDp = ffi.new("double*[?]", nFluids)
-   local emDp = ffi.new("double*")
-   local staticEmDp = ffi.new("double*")
-   local sigmaDp = ffi.new("double*")
-   local auxSrcDp = ffi.new("double[?]", 3*(nFluids+1))
-
-   -- loop over local range, updating source in each cell
-   for idx in emFld:localRangeIter() do
-      grid:setIndex(idx)
-      grid:cellCenter(xc)
-
-      -- set pointers to fluids and field
-      for i = 1, nFluids do
-	 fDp[i-1] = outFld[i]:getDataPtrAt(fIdxr[i](idx))
-      end
-      emDp = emFld:getDataPtrAt(emIdxr(idx))
-      if (self._sd.hasStatic) then
-         staticEmDp = staticEmFld:getDataPtrAt(staticEmIdxr(idx))
-      end
-      if (self._sd.hasSigma) then
-         sigmaDp = self._sigmaFld:getDataPtrAt(sigmaIdxr(idx))
+   if target=="gpu" then
+      local fluidFlds = ffi.new("GkylCartField_t*[?]", nFluids)
+      for n = 1, nFluids do
+         fluidFlds[n-1] = outFld[n]._onDevice
       end
 
-      if (self._sd.hasAuxSrc) then
-         self:_auxSrcFunc(
-            xc, tCurr, self._sd.epsilon0, self._qbym, fDp, emDp, auxSrcDp)
+      -- pre-compute d_fluidFlds
+      local sz_fluidFlds = sizeof("GkylCartField_t*") * self._sd.nFluids
+      cuda.Memcpy(
+         self.d_fluidFlds, fluidFlds, sz_fluidFlds, cuda.MemcpyHostToDevice)
+      local d_emFld = emFld._onDevice
+
+      local numCellsLocal = emFld:localRange():volume()
+      local numThreads = math.min(self.numThreads, numCellsLocal)
+      local numBlocks  = math.ceil(numCellsLocal/numThreads)
+
+      ffi.C.momentSrcAdvanceOnDevice(
+       numBlocks, numThreads, self.sd_onDevice, self.fd_onDevice, dt,
+       self.d_fluidFlds, d_emFld)
+   elseif target=="cpu" then
+      -- allocate stuff to pass to C
+      local fDp = ffi.new("double*[?]", nFluids)
+      local emDp = ffi.new("double*")
+      local staticEmDp = ffi.new("double*")
+      local sigmaDp = ffi.new("double*")
+      local auxSrcDp = ffi.new("double[?]", 3*(nFluids+1))
+
+      -- loop over local range, updating source in each cell
+      for idx in emFld:localRangeIter() do
+         grid:setIndex(idx)
+         grid:cellCenter(xc)
+
+         -- set pointers to fluids and field
+         for i = 1, nFluids do
+       fDp[i-1] = outFld[i]:getDataPtrAt(fIdxr[i](idx))
+         end
+         emDp = emFld:getDataPtrAt(emIdxr(idx))
+         if (self._sd.hasStatic) then
+            staticEmDp = staticEmFld:getDataPtrAt(staticEmIdxr(idx))
+         end
+         if (self._sd.hasSigma) then
+            sigmaDp = self._sigmaFld:getDataPtrAt(sigmaIdxr(idx))
+         end
+
+         if (self._sd.hasAuxSrc) then
+            self:_auxSrcFunc(
+               xc, tCurr, self._sd.epsilon0, self._qbym, fDp, emDp, auxSrcDp)
+         end
+
+         -- update sources
+         self._updateSrc(self, dt, fDp, emDp, staticEmDp, sigmaDp, auxSrcDp)
       end
 
-      -- update sources
-      self._updateSrc(self, dt, fDp, emDp, staticEmDp, sigmaDp, auxSrcDp)
+      return true, GKYL_MAX_DOUBLE
+   else
+      assert(false, string.format("target %s not recognized", target))
    end
+end
 
-   return true, GKYL_MAX_DOUBLE
+-- advance method
+function FiveMomentSrc:_advance(tCurr, inFld, outFld)
+   self:_advanceDispatch(tCurr, inFld, outFld, "cpu")
+end
+
+-- advance method
+function FiveMomentSrc:_advanceDevice(tCurr, inFld, outFld)
+   self:_advanceDispatch(tCurr, inFld, outFld, "gpu")
 end
 
 return FiveMomentSrc

--- a/Updater/GkylMomentSrc.h
+++ b/Updater/GkylMomentSrc.h
@@ -13,4 +13,31 @@ extern "C" {
         double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);
 }
 
+#define cudacall(call)                                                                                                          \
+    do                                                                                                                          \
+    {                                                                                                                           \
+        cudaError_t err = (call);                                                                                               \
+        if(cudaSuccess != err)                                                                                                  \
+        {                                                                                                                       \
+            fprintf(stderr,"CUDA Error:\nFile = %s\nLine = %d\nReason = %s\n", __FILE__, __LINE__, cudaGetErrorString(err));    \
+            cudaDeviceReset();                                                                                                  \
+            exit(EXIT_FAILURE);                                                                                                 \
+        }                                                                                                                       \
+    }                                                                                                                           \
+    while (0)
+
+#define cublascall(call)                                                                                        \
+    do                                                                                                          \
+    {                                                                                                           \
+        cublasStatus_t status = (call);                                                                         \
+        if(CUBLAS_STATUS_SUCCESS != status)                                                                     \
+        {                                                                                                       \
+            fprintf(stderr,"CUBLAS Error:\nFile = %s\nLine = %d\nCode = %d\n", __FILE__, __LINE__, status);     \
+            cudaDeviceReset();                                                                                  \
+            exit(EXIT_FAILURE);                                                                                 \
+        }                                                                                                       \
+                                                                                                                \
+    }                                                                                                           \
+    while(0)
+
 #endif // GKYL_MOMENT_SRC_H

--- a/Updater/GkylMomentSrc.h
+++ b/Updater/GkylMomentSrc.h
@@ -1,0 +1,16 @@
+
+#ifndef GKYL_MOMENT_SRC_H
+#define GKYL_MOMENT_SRC_H
+
+#include <GkylCudaConfig.h>
+#include <MomentSrcCommon.h>
+#include <GkylCartField.h>
+
+extern "C" {
+    /* CUDA GPU */
+    void momentSrcAdvanceOnDevice(
+        int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
+        double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);
+}
+
+#endif // GKYL_MOMENT_SRC_H

--- a/Updater/MomentSrcCommonDevice.cu
+++ b/Updater/MomentSrcCommonDevice.cu
@@ -171,27 +171,28 @@ static int cuda_gkylMomentSrcTimeCentered(
       batchSize // number of pointers contained in A
       );
   if (status != CUBLAS_STATUS_SUCCESS) {
-    fprintf(stderr, "!!!! LU decomposition kernel execution error.\n");
+    fprintf(stderr, "!!!! LU decomposition kernel getrf execution error.\n");
     return EXIT_FAILURE;
   }
 
-  /* status = cublasDgetrsBatched( */
-  /*     handle, */
-  /*     CUBLAS_OP_N,  // trans */
-  /*     N,  // n */
-  /*     1,  // nrhs */
-  /*     &d_lhs,  // matrix A */
-  /*     N,  // lda */
-  /*     NULL,  // const int *devIpiv */
-  /*     &d_rhs,  // double *Barray[] */
-  /*     N,  // ldb */
-  /*     NULL,  // int *info */
-  /*     batchSize // number of pointers contained in A */
-  /*     ); */
-  /* if (status != CUBLAS_STATUS_SUCCESS) { */
-  /*   fprintf(stderr, "!!!! solve kernel execution error.\n"); */
-  /*   return EXIT_FAILURE; */
-  /* } */
+  int info;
+  status = cublasDgetrsBatched(
+      handle,
+      CUBLAS_OP_N,  // trans
+      N,  // n
+      1,  // nrhs
+      d_lhs_ptr,  // matrix A
+      N,  // lda
+      NULL,  // const int *devIpiv
+      d_rhs_ptr,  // double *Barray[]
+      N,  // ldb
+      &info,  // int *info
+      batchSize // number of pointers contained in A
+      );
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    fprintf(stderr, "!!!! solve kernel getrs execution error.\n");
+    return EXIT_FAILURE;
+  }
 
   // update solution
 

--- a/Updater/MomentSrcCommonDevice.cu
+++ b/Updater/MomentSrcCommonDevice.cu
@@ -1,0 +1,197 @@
+#include <cstdio>
+#include <GkylMomentSrc.h>
+#include <GkylCudaConfig.h>
+
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+
+// Makes indexing cleaner
+#define X (0)
+#define Y (1)
+#define Z (2)
+
+#define RHO (0)
+#define MX (1)
+#define MY (2)
+#define MZ (3)
+#define ER (4)
+
+#define EX (0)
+#define EY (1)
+#define EZ (2)
+#define BX (3)
+#define BY (4)
+#define BZ (5)
+#define PHIE (6)
+#define PHIM (7)
+
+#define fidx(n, c) (3 * (n) + (c))
+#define eidx(c) (3 * nFluids + (c))
+
+#define N (9)
+#define sq(x) ((x) * (x))
+
+#define F2(base,i,j) (base)[(j)*N+(i)]
+
+__global__ void cuda_gkylMomentSrcSetMat(
+    MomentSrcData_t *sd, FluidData_t *fd, double dt, GkylCartField_t **fluidFlds,
+    GkylCartField_t *emFld, double *d_lhs, double *d_rhs) {
+  GkylRange_t *localRange = emFld->localRange;
+  Gkyl::GenIndexer localIdxr(localRange);
+  Gkyl::GenIndexer fIdxr = emFld->genIndexer();
+
+  // numThreads*numBlocks == numRealCells
+  int linearIdx = threadIdx.x + blockIdx.x*blockDim.x;
+  int idxC[3];
+  localIdxr.invIndex(linearIdx, idxC);
+  const int linearIdxC = fIdxr.index(idxC);
+  const double *em = emFld->getDataPtrAt(linearIdxC);
+
+  double *lhs = d_lhs + (N*N)*sizeof(double)*linearIdx;
+  double *rhs = d_rhs + (N)*sizeof(double)*linearIdx;
+
+  unsigned nFluids = sd->nFluids;
+  double dt1 = 0.5 * dt;
+  double dt2 = 0.5 * dt / sd->epsilon0;
+
+  for (unsigned n=0; n<nFluids; ++n)
+  {
+    double qbym = fd[n].charge/fd[n].mass;
+    double qbym2 = sq(qbym);
+
+    const double *f = fluidFlds[n]->getDataPtrAt(linearIdxC);
+    if (fd[n].evolve) {
+      // off-diagonal elements of lhs
+      // eqn. for X-component of current
+      F2(lhs, fidx(n,X), fidx(n,Y)) = -dt1*qbym*(em[BZ]);
+      F2(lhs, fidx(n,X), fidx(n,Z)) = dt1*qbym*(em[BY]);
+      F2(lhs, fidx(n,X), eidx(X)) = -dt1*qbym2*f[RHO];
+
+      // eqn. for Y-component of current
+      F2(lhs, fidx(n,Y), fidx(n,X)) = dt1*qbym*(em[BZ]);
+      F2(lhs, fidx(n,Y), fidx(n,Z)) = -dt1*qbym*(em[BX]);
+      F2(lhs, fidx(n,Y), eidx(Y)) = -dt1*qbym2*f[RHO];
+
+      // eqn. for Z-component of current
+      F2(lhs, fidx(n,Z), fidx(n,X)) = -dt1*qbym*(em[BY]);
+      F2(lhs, fidx(n,Z), fidx(n,Y)) = dt1*qbym*(em[BX]);
+      F2(lhs, fidx(n,Z), eidx(Z)) = -dt1*qbym2*f[RHO];
+    }
+    // diagonal elements of lhs
+    F2(lhs, fidx(n,X), fidx(n,X)) = 1.0;
+    F2(lhs, fidx(n,Y), fidx(n,Y)) = 1.0;
+    F2(lhs, fidx(n,Z), fidx(n,Z)) = 1.0;
+
+    // fill corresponding RHS elements
+    rhs[fidx(n,X)] = qbym*f[MX];
+    rhs[fidx(n,Y)] = qbym*f[MY];
+    rhs[fidx(n,Z)] = qbym*f[MZ];
+
+    // set current contribution to electric field equation
+    F2(lhs, eidx(X), fidx(n,X)) = dt2;
+    F2(lhs, eidx(Y), fidx(n,Y)) = dt2;
+    F2(lhs, eidx(Z), fidx(n,Z)) = dt2;
+  }
+
+  // fill in elements for electric field equations
+  F2(lhs, eidx(EX), eidx(EX)) = 1.0;
+  F2(lhs, eidx(EY), eidx(EY)) = 1.0;
+  F2(lhs, eidx(EZ), eidx(EZ)) = 1.0;
+
+  rhs[eidx(EX)] = em[EX];
+  rhs[eidx(EY)] = em[EY];
+  rhs[eidx(EZ)] = em[EZ];
+}
+
+static int cuda_gkylMomentSrcTimeCentered(
+    int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
+    double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld) {
+  // FIXME save d_lhs and avoid reallocating?
+  cublasStatus_t status;
+  double *d_lhs = 0;
+  double *d_rhs = 0;
+  cublasHandle_t handle;
+
+  int batchSize = numThreads*numBlocks;
+
+  status = cublasCreate(&handle);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    fprintf(stderr, "!!!! CUBLAS initialization error\n");
+    return EXIT_FAILURE;
+  }
+
+  if (cudaMalloc(reinterpret_cast<void **>(&d_lhs), N*N * sizeof(d_lhs[0])) !=
+      cudaSuccess) {
+    fprintf(stderr, "!!!! device memory allocation error (allocate A)\n");
+    return EXIT_FAILURE;
+  }
+
+  if (cudaMalloc(reinterpret_cast<void **>(&d_rhs), N * sizeof(d_rhs[0])) !=
+      cudaSuccess) {
+    fprintf(stderr, "!!!! device memory allocation error (allocate A)\n");
+    return EXIT_FAILURE;
+  }
+
+  cuda_gkylMomentSrcSetMat<<<numBlocks, numThreads>>>(
+      sd, fd, dt, fluidFlds, emFld, d_lhs, d_rhs);
+
+  /* status = cublasDgetrfBatched( */
+  /*     handle, */
+  /*     N,  // n */
+  /*     &d_lhs,  // A */
+  /*     N,  // lda */
+  /*     NULL,  // int *PivotArray */
+  /*     NULL,  // int *infoArray */
+  /*     batchSize // number of pointers contained in A */
+  /*     ); */
+  /* if (status != CUBLAS_STATUS_SUCCESS) { */
+  /*   fprintf(stderr, "!!!! LU decomposition kernel execution error.\n"); */
+  /*   return EXIT_FAILURE; */
+  /* } */
+  /*  */
+  /* status = cublasDgetrsBatched( */
+  /*     handle, */
+  /*     CUBLAS_OP_N,  // trans */
+  /*     N,  // n */
+  /*     1,  // nrhs */
+  /*     &d_lhs,  // matrix A */
+  /*     N,  // lda */
+  /*     NULL,  // const int *devIpiv */
+  /*     &d_rhs,  // double *Barray[] */
+  /*     N,  // ldb */
+  /*     NULL,  // int *info */
+  /*     batchSize // number of pointers contained in A */
+  /*     ); */
+  /* if (status != CUBLAS_STATUS_SUCCESS) { */
+  /*   fprintf(stderr, "!!!! solve kernel execution error.\n"); */
+  /*   return EXIT_FAILURE; */
+  /* } */
+
+  // update solution
+
+  if (cudaFree(d_lhs) != cudaSuccess) {
+    fprintf(stderr, "!!!! memory free error (d_lhs)\n");
+    return EXIT_FAILURE;
+  }
+
+  if (cudaFree(d_rhs) != cudaSuccess) {
+    fprintf(stderr, "!!!! memory free error (d_rhs)\n");
+    return EXIT_FAILURE;
+  }
+ 
+  status = cublasDestroy(handle);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    fprintf(stderr, "!!!! shutdown error (A)\n");
+    return EXIT_FAILURE;
+  }
+ 
+  exit(EXIT_SUCCESS);
+}
+
+void momentSrcAdvanceOnDevice(
+    int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
+    double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld)
+{
+  cuda_gkylMomentSrcTimeCentered(
+      numBlocks, numThreads, sd, fd, dt, fluidFlds, emFld);
+}

--- a/Updater/MomentSrcCommonDevice.cu
+++ b/Updater/MomentSrcCommonDevice.cu
@@ -172,7 +172,7 @@ __global__ void cuda_gkylMomentSrcSetMat(
   rhs[eidx(EZ)] = em[EZ];
 }
 
-static int cuda_gkylMomentSrcTimeCentered(
+static cudaError_t cuda_gkylMomentSrcTimeCentered(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld) {
   // FIXME save d_lhs and avoid reallocating?
@@ -240,6 +240,8 @@ static int cuda_gkylMomentSrcTimeCentered(
   cudacall(cudaFree(d_info));
 
   cublascall(cublasDestroy(handle));
+
+  return cudaSuccess;
 }
 
 void momentSrcAdvanceOnDevice(

--- a/Updater/wscript
+++ b/Updater/wscript
@@ -401,6 +401,7 @@ def build(bld):
         momentCalcData/DistFuncMomentCalcDeviceWrappers.cu
 
         WavePropagationDevice.cu
+        MomentSrcCommonDevice.cu
         """
         
         bld(source = cusources,

--- a/machines/configure.adroit-intel-mpi.sh
+++ b/machines/configure.adroit-intel-mpi.sh
@@ -40,10 +40,10 @@ EIGEN_INC_DIR=$HOME/gkylsoft/eigen3/include/eigen3
 # CUDA options
 CUTOOLS_INC_DIR=$CPATH
 CUTOOLS_LIB_DIR=$LIBRARY_PATH
-CUTOOLS_LINK_LIBS=cudart
+CUTOOLS_LINK_LIBS="cudart"
 
 # You probably do not need to modify the command itself
-cmd="./waf CC=$CC CXX=$CXX MPICC=$MPICC MPICXX=$MPICXX --out=$OUT --prefix=$PREFIX --cxxflags=$CXXFLAGS --luajit-inc-dir=$LUAJIT_INC_DIR --luajit-lib-dir=$LUAJIT_LIB_DIR --luajit-share-dir=$LUAJIT_SHARE_DIR $ENABLE_MPI --mpi-inc-dir=$MPI_INC_DIR --mpi-lib-dir=$MPI_LIB_DIR --mpi-link-libs=$MPI_LINK_LIBS $ENABLE_ADIOS --adios-inc-dir=$ADIOS_INC_DIR --adios-lib-dir=$ADIOS_LIB_DIR --cuda-inc-dir=$CUTOOLS_INC_DIR --cuda-lib-dir=$CUTOOLS_LIB_DIR configure"
+cmd="./waf CC=$CC CXX=$CXX MPICC=$MPICC MPICXX=$MPICXX --out=$OUT --prefix=$PREFIX --cxxflags=$CXXFLAGS --luajit-inc-dir=$LUAJIT_INC_DIR --luajit-lib-dir=$LUAJIT_LIB_DIR --luajit-share-dir=$LUAJIT_SHARE_DIR $ENABLE_MPI --mpi-inc-dir=$MPI_INC_DIR --mpi-lib-dir=$MPI_LIB_DIR --mpi-link-libs=$MPI_LINK_LIBS $ENABLE_ADIOS --adios-inc-dir=$ADIOS_INC_DIR --adios-lib-dir=$ADIOS_LIB_DIR --cuda-inc-dir=$CUTOOLS_INC_DIR --cuda-lib-dir=$CUTOOLS_LIB_DIR --cuda-link-libs=$CUTOOLS_LINK_LIBS configure"
 # if we are in machines directory, go up a directory before executing cmd
 if [ `dirname "$0"` == "." ] 
   then

--- a/machines/configure.adroit-intel-mpi.sh
+++ b/machines/configure.adroit-intel-mpi.sh
@@ -40,7 +40,7 @@ EIGEN_INC_DIR=$HOME/gkylsoft/eigen3/include/eigen3
 # CUDA options
 CUTOOLS_INC_DIR=$CPATH
 CUTOOLS_LIB_DIR=$LIBRARY_PATH
-CUTOOLS_LINK_LIBS="cudart"
+CUTOOLS_LINK_LIBS="cudart,cublas"
 
 # You probably do not need to modify the command itself
 cmd="./waf CC=$CC CXX=$CXX MPICC=$MPICC MPICXX=$MPICXX --out=$OUT --prefix=$PREFIX --cxxflags=$CXXFLAGS --luajit-inc-dir=$LUAJIT_INC_DIR --luajit-lib-dir=$LUAJIT_LIB_DIR --luajit-share-dir=$LUAJIT_SHARE_DIR $ENABLE_MPI --mpi-inc-dir=$MPI_INC_DIR --mpi-lib-dir=$MPI_LIB_DIR --mpi-link-libs=$MPI_LINK_LIBS $ENABLE_ADIOS --adios-inc-dir=$ADIOS_INC_DIR --adios-lib-dir=$ADIOS_LIB_DIR --cuda-inc-dir=$CUTOOLS_INC_DIR --cuda-lib-dir=$CUTOOLS_LIB_DIR --cuda-link-libs=$CUTOOLS_LINK_LIBS configure"


### PR DESCRIPTION
- Using `cublasDgetrfBatched` and `cublasDgetrsBatched` for soling `Ax=b` for `x`.
- A unit test passes.
  - 5m source update, GPU vs. CPU Eigen vs. CPU direct solution.

Thoughts for next work:
- Memory limitation: Batched calls require pre-allocate memory for all cells.
  - Using `cuSolver`'s unbatched `getrf`/`getrs` functions dos not sound to help directly, since memory needs to be allocated any way for all cells.
  - Plus, `cuSolver` seems to more fit for solve single big matrices (I'm not sure)?
  - We need to do a domain decomposition and process a small tile of cells per thread each time.
  - The actual allocation operation now happening in the kernel should be moved to the upper-level Lua code to avoid repeated allocation.
- Other logic stuff:
  - Separate out energy/pressure tensor update.
  - Reduce the number of relevant files.