### PR TITLE
cuda_source5m2

### DIFF
--- a/Cuda/GkylCudaConfig.h
+++ b/Cuda/GkylCudaConfig.h
@@ -18,4 +18,31 @@
 #include <cuda_runtime.h>
 #endif
 
+#define cudacall(call)                                                                                                          \
+    do                                                                                                                          \
+    {                                                                                                                           \
+        cudaError_t err = (call);                                                                                               \
+        if(cudaSuccess != err)                                                                                                  \
+        {                                                                                                                       \
+            fprintf(stderr,"CUDA Error:\nFile = %s\nLine = %d\nReason = %s\n", __FILE__, __LINE__, cudaGetErrorString(err));    \
+            cudaDeviceReset();                                                                                                  \
+            exit(EXIT_FAILURE);                                                                                                 \
+        }                                                                                                                       \
+    }                                                                                                                           \
+    while (0)
+
+#define cublascall(call)                                                                                        \
+    do                                                                                                          \
+    {                                                                                                           \
+        cublasStatus_t status = (call);                                                                         \
+        if(CUBLAS_STATUS_SUCCESS != status)                                                                     \
+        {                                                                                                       \
+            fprintf(stderr,"CUBLAS Error:\nFile = %s\nLine = %d\nCode = %d\n", __FILE__, __LINE__, status);     \
+            cudaDeviceReset();                                                                                  \
+            exit(EXIT_FAILURE);                                                                                 \
+        }                                                                                                       \
+                                                                                                                \
+    }                                                                                                           \
+    while(0)
+
 #endif // GK_CUDA_CONFIG_H

--- a/Eq/Euler.lua
+++ b/Eq/Euler.lua
@@ -283,13 +283,9 @@ local Euler = Proto(EqBase)
 function Euler:init(tbl)
    self._gasGamma = tbl.gasGamma
    self.eulerObj = EulerObj(tbl)
-
-   if GKYL_HAVE_CUDA then
-     self:initDevice()
-   end
 end
 
-function Euler:initDevice()
+function Euler:initDevice(tbl)
    self._onHost = ffi.C.new_Euler(self._gasGamma)
    self._onDevice = ffi.C.new_Euler_onDevice(self._onHost)
 end

--- a/Unit/test_FiveMomentSrcDevice.lua
+++ b/Unit/test_FiveMomentSrcDevice.lua
@@ -25,9 +25,9 @@ local assert_close = Unit.assert_close
 local stats = Unit.stats
 
 local nx = 128*64 -- number of configuration space dimensions in x
-local nloop = NLOOP or 1 -- number of WavePropagation calls to loop over
+local nloop = NLOOP or 3 -- number of WavePropagation calls to loop over
 local numThreads = NTHREADS or 128 -- number of threads to use in WavePropagation kernel configuration
-local checkResult = xsys.pickBool(CHECK, true)
+local checkResult = xsys.pickBool(CHECK, true) and false
 
 local grid = Grid.RectCart {
    lower = {0.0},

--- a/Unit/test_FiveMomentSrcDevice.lua
+++ b/Unit/test_FiveMomentSrcDevice.lua
@@ -17,41 +17,22 @@ local Unit = require "Unit"
 local Grid = require "Grid"
 local DataStruct = require "DataStruct"
 local Updater = require "Updater"
+local Time = require "Lib.Time"
+local xsys = require "xsys"
 
 local assert_equal = Unit.assert_equal
 local assert_close = Unit.assert_close
 local stats = Unit.stats
 
-local computeMaxFreq = function(charge, mass, rho, Bmag, epsilon0, show)
-   local wp_tot = 0
-   local wc_max = 0
-   for species,_ in ipairs(charge)  do
-      local wp2 = rho[species] * (charge[species] / mass[species])^2 / epsilon0
-      wp_tot = wp_tot + wp2
-      wc_max = math.max(wc_max, math.abs(charge[species] * Bmag / mass[species]))
-   end
-   wp_tot = math.sqrt(wp_tot)
-
-   if show then
-      for species = 1,#charge do
-         print(string.format("species [%d] charge=%g, mass=%g, rho=%g",
-            species, charge[species], mass[species], rho[species]))
-      end
-      print('Bmag=%g, epsilon0=%g')
-
-      print('wp_tot', wp_tot)
-      print('2*pi/wp_tot', 2*math.pi/wp_tot)
-      print('wc_max', wc_max)
-      print('2*pi/wc_max', 2*math.pi/wc_max)
-   end
-
-   return math.max(wp_tot, wc_max)
-end
+local nx = 128*64 -- number of configuration space dimensions in x
+local nloop = NLOOP or 1 -- number of WavePropagation calls to loop over
+local numThreads = NTHREADS or 128 -- number of threads to use in WavePropagation kernel configuration
+local checkResult = xsys.pickBool(CHECK, true)
 
 local grid = Grid.RectCart {
    lower = {0.0},
    upper = {1.0},
-   cells = {1},
+   cells = {nx},
 }
 
 local fluid1 = DataStruct.Field {
@@ -86,6 +67,31 @@ local d_emf = DataStruct.Field {
 local epsilon0 = 1.0
 local gasGamma = 5. / 3.
 
+local computeMaxFreq = function(charge, mass, rho, Bmag, epsilon0, show)
+   local wp_tot = 0
+   local wc_max = 0
+   for species,_ in ipairs(charge)  do
+      local wp2 = rho[species] * (charge[species] / mass[species])^2 / epsilon0
+      wp_tot = wp_tot + wp2
+      wc_max = math.max(wc_max, math.abs(charge[species] * Bmag / mass[species]))
+   end
+   wp_tot = math.sqrt(wp_tot)
+
+   if show then
+      for species = 1,#charge do
+         print(string.format("species [%d] charge=%g, mass=%g, rho=%g",
+            species, charge[species], mass[species], rho[species]))
+      end
+      print('Bmag=%g, epsilon0=%g')
+
+      print('wp_tot', wp_tot)
+      print('2*pi/wp_tot', 2*math.pi/wp_tot)
+      print('wc_max', wc_max)
+      print('2*pi/wc_max', 2*math.pi/wc_max)
+   end
+
+   return math.max(wp_tot, wc_max)
+end
 
 function init(
    fluid1, fluid2, emf,
@@ -175,47 +181,63 @@ function doTest1(scheme, dtFrac)
    }
    srcUpdater:setDtAndCflRate(dt, nil)
 
-   srcUpdater:advance(0.0, {}, {fluid1, fluid2, emf})
+   tmStart = Time.clock()
+   for i = 1, nloop do
+      srcUpdater:_advanceDevice(0.0, {}, {d_fluid1, d_fluid2, d_emf})
+   end
+   local err = cuda.DeviceSynchronize()
+   local totalGpuTime = (Time.clock()-tmStart)
 
-   srcUpdater:_advanceDevice(0.0, {}, {d_fluid1, d_fluid2, d_emf})
    d_fluid1:copyDeviceToHost()
    d_fluid2:copyDeviceToHost()
    d_emf:copyDeviceToHost()
 
-   local f1Idxr = fluid1:genIndexer()   
-   local f2Idxr = fluid2:genIndexer()   
-   local emIdxr = emf:genIndexer() 
-   local d_f1Idxr = d_fluid1:genIndexer()   
-   local d_f2Idxr = d_fluid2:genIndexer()   
-   local d_emIdxr = d_emf:genIndexer() 
-
-   for idx in fluid1:localRangeIter() do
-      local f1 = fluid1:get(f1Idxr(idx))
-      local d_f1 = d_fluid1:get(d_f1Idxr(idx))
-      for comp = 1,5 do
-         assert_close(f1[comp], d_f1[comp], 1e-10, string.format(
-         "fluid1 index %d component %d is incorrect", f1Idxr(idx), comp))
-      end
-
-      local f2 = fluid1:get(f2Idxr(idx))
-      local d_f2 = d_fluid1:get(d_f2Idxr(idx))
-      for comp = 1,5 do
-         assert_close(f2[comp], d_f2[comp], 1e-10, string.format(
-         "fluid2 index %d component %d is incorrect", f2Idxr(idx), comp))
-      end
-
-      local em = fluid1:get(emIdxr(idx))
-      local d_em = d_fluid1:get(d_emIdxr(idx))
-      for comp = 1,8 do
-         assert_close(em[comp], d_em[comp], 1e-10, string.format(
-         "emf index %d component %d is incorrect", emIdxr(idx), comp))
-      end
-
+   tmStart = Time.clock()
+   for i = 1, nloop do
+      srcUpdater:advance(0.0, {}, {fluid1, fluid2, emf})
    end
+   local totalCpuTime = (Time.clock()-tmStart)
+
+   if checkResult then
+      local f1Idxr = fluid1:genIndexer()   
+      local f2Idxr = fluid2:genIndexer()   
+      local emIdxr = emf:genIndexer() 
+      local d_f1Idxr = d_fluid1:genIndexer()   
+      local d_f2Idxr = d_fluid2:genIndexer()   
+      local d_emIdxr = d_emf:genIndexer() 
+
+      for idx in fluid1:localRangeIter() do
+         local f1 = fluid1:get(f1Idxr(idx))
+         local d_f1 = d_fluid1:get(d_f1Idxr(idx))
+         for comp = 1,5 do
+            assert_close(f1[comp], d_f1[comp], 1e-10, string.format(
+            "fluid1 index %d component %d is incorrect", f1Idxr(idx), comp))
+         end
+
+         local f2 = fluid1:get(f2Idxr(idx))
+         local d_f2 = d_fluid1:get(d_f2Idxr(idx))
+         for comp = 1,5 do
+            assert_close(f2[comp], d_f2[comp], 1e-10, string.format(
+            "fluid2 index %d component %d is incorrect", f2Idxr(idx), comp))
+         end
+
+         local em = fluid1:get(emIdxr(idx))
+         local d_em = d_fluid1:get(d_emIdxr(idx))
+         for comp = 1,8 do
+            assert_close(em[comp], d_em[comp], 1e-10, string.format(
+            "emf index %d component %d is incorrect", emIdxr(idx), comp))
+         end
+      end
+   end
+
+   print("cpu scheme", scheme)
+   print(string.format("Total CPU time for %d FiveMomentSrc calls = %f s   (average = %f s)", nx, totalCpuTime, totalCpuTime/nx))
+   print(string.format("Total GPU time for %d FiveMomentSrc calls = %f s   (average = %f s)", nx, totalGpuTime, totalGpuTime/nx))
+   print(string.format("GPU speed-up = %fx!", totalCpuTime/totalGpuTime))
 
 end
 
-doTest1("time-centered", 0.1)
+doTest1("time-centered", 1)
 doTest1("direct", 1)
 
 -- TODO Do automatic check.

--- a/Updater/FiveMomentSrc.lua
+++ b/Updater/FiveMomentSrc.lua
@@ -189,16 +189,18 @@ end
 
 
 function FiveMomentSrc:initDevice(tbl)
+   local nFluids = self._sd.nFluids
+
    local sz_sd = sizeof("MomentSrcData_t")
    self.sd_onDevice, err = cuda.Malloc(sz_sd)
    cuda.Memcpy(self.sd_onDevice, self._sd, sz_sd, cuda.MemcpyHostToDevice)
 
-   local sz_fd = sizeof("FluidData_t") * self._sd.nFluids
+   local sz_fd = sizeof("FluidData_t") * nFluids
    self.fd_onDevice, err = cuda.Malloc(sz_fd)
    cuda.Memcpy(
       self.fd_onDevice, self._fd, sz_fd , cuda.MemcpyHostToDevice)
 
-   local sz_fluidFlds = sizeof("GkylCartField_t*") * self._sd.nFluids
+   local sz_fluidFlds = sizeof("GkylCartField_t*") * nFluids
    self.d_fluidFlds, err = cuda.Malloc(sz_fluidFlds)
 
    self.numThreads = tbl.numThreads or GKYL_DEFAULT_NUM_THREADS
@@ -207,7 +209,7 @@ function FiveMomentSrc:initDevice(tbl)
    local numThreads = math.min(self.numThreads, numCellsLocal)
    local numBlocks  = math.ceil(numCellsLocal/numThreads)
    self.device_context = ffi.C.cuda_gkylMomentSrcInit(
-      numBlocks, numThreads)
+      nFluids, numBlocks, numThreads)
    self.numThreads = numThreads
    self.numBlocks = numBlocks
    self.numCellsLocal = numCellsLocal

--- a/Updater/FiveMomentSrc.lua
+++ b/Updater/FiveMomentSrc.lua
@@ -59,24 +59,23 @@ typedef struct {
   typedef struct cublasContext *cublasHandle_t;
 
   typedef struct {
-    // TODO domain decomposition info
     double *d_lhs;
     double *d_rhs;
     double **d_lhs_ptr;
     double **d_rhs_ptr;
     int *d_info;
     cublasHandle_t handle;
-  } GkylMomentSrcDeviceCUBLAS_t;
+  } GkylMomentSrcDeviceData_t;
 
 
-  GkylMomentSrcDeviceCUBLAS_t *cuda_gkylMomentSrcTimeCenteredInit(
+  GkylMomentSrcDeviceData_t *cuda_gkylMomentSrcTimeCenteredInit(
       int numBlocks, int numThreads);
   void cuda_gkylMomentSrcTimeCenteredDestroy(
-      GkylMomentSrcDeviceCUBLAS_t *context);
+      GkylMomentSrcDeviceData_t *context);
   void momentSrcAdvanceOnDevicePreAlloc(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
-    GkylMomentSrcDeviceCUBLAS_t *context);
+    GkylMomentSrcDeviceData_t *context);
 ]]
 
 -- Explicit, SSP RK3 scheme

--- a/Updater/FiveMomentSrc.lua
+++ b/Updater/FiveMomentSrc.lua
@@ -214,10 +214,14 @@ function FiveMomentSrc:initDevice(tbl)
    -- callback into proxy.__gc when the proxy becomes free
    -- FIXME Is this the correct way?
    local prox = newproxy(true)
+   self.cublas_freed = false
    getmetatable(prox).__gc = function()
-      ffi.C.cuda_gkylMomentSrcTimeCenteredDestroy(self.cublas_context)
-      self[prox] = true
+      if self.cublas_freed  then
+        ffi.C.cuda_gkylMomentSrcTimeCenteredDestroy(self.cublas_context)
+     end
+     self.cublas_freed = true
    end
+   self[prox] = true
 end
 
 

--- a/Updater/FiveMomentSrc.lua
+++ b/Updater/FiveMomentSrc.lua
@@ -207,9 +207,14 @@ function FiveMomentSrc:initDevice(tbl)
 
    self.numThreads = tbl.numThreads or GKYL_DEFAULT_NUM_THREADS
 
-   -- FIXME not initializing cublas_context here because numBlocks is not known
-   -- yet; also numThreds could be different from actual values to be used
-   self.first = true
+   local numCellsLocal = self._onGrid:localRange():volume()
+   local numThreads = math.min(self.numThreads, numCellsLocal)
+   local numBlocks  = math.ceil(numCellsLocal/numThreads)
+   self.cublas_context = ffi.C.cuda_gkylMomentSrcTimeCenteredInit(
+      numBlocks, numThreads)
+   self.numThreads = numThreads
+   self.numBlocks = numBlocks
+   self.numCellsLocal = numCellsLocal
 
    -- callback into proxy.__gc when the proxy becomes free
    -- FIXME Is this the correct way?
@@ -272,20 +277,10 @@ function FiveMomentSrc:_advanceDispatch(tCurr, inFld, outFld, target)
       local d_emFld = emFld._onDevice
 
       local numCellsLocal = emFld:localRange():volume()
-      local numThreads = math.min(self.numThreads, numCellsLocal)
-      local numBlocks  = math.ceil(numCellsLocal/numThreads)
+      assert(numCellsLocal == self.numCellsLocal)
 
-      if self.first then
-         self.cublas_context = ffi.C.cuda_gkylMomentSrcTimeCenteredInit(
-            numBlocks, numThreads)
-         self.first = false
-      end
-
-      -- ffi.C.momentSrcAdvanceOnDevice(
-      --  numBlocks, numThreads, self.sd_onDevice, self.fd_onDevice, dt,
-      --  self.d_fluidFlds, d_emFld)
       ffi.C.momentSrcAdvanceOnDevicePreAlloc(
-       numBlocks, numThreads, self.sd_onDevice, self.fd_onDevice, dt,
+       self.numBlocks, self.numThreads, self.sd_onDevice, self.fd_onDevice, dt,
        self.d_fluidFlds, d_emFld, self.cublas_context)
 
       return true, GKYL_MAX_DOUBLE

--- a/Updater/FiveMomentSrc.lua
+++ b/Updater/FiveMomentSrc.lua
@@ -71,6 +71,8 @@ typedef struct {
 
   GkylMomentSrcDeviceCUBLAS_t *cuda_gkylMomentSrcTimeCenteredInit(
       int numBlocks, int numThreads);
+  void cuda_gkylMomentSrcTimeCenteredDestroy(
+      GkylMomentSrcDeviceCUBLAS_t *context);
   void momentSrcAdvanceOnDevicePreAlloc(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
@@ -208,6 +210,11 @@ function FiveMomentSrc:initDevice(tbl)
    -- FIXME not initializing cublas_context here because numBlocks is not known
    -- yet; also numThreds could be different from actual values to be used
    self.first = true
+
+   local prox = newproxy(true)
+   getmetatable(prox).__gc = function()
+      ffi.C.cuda_gkylMomentSrcTimeCenteredDestroy(self.cublas_context)
+   end
 end
 
 

--- a/Updater/FiveMomentSrc.lua
+++ b/Updater/FiveMomentSrc.lua
@@ -54,10 +54,27 @@ typedef struct {
   void gkylFiveMomentSrcExact(MomentSrcData_t *sd, FluidData_t *fd, double dt, double **ff, double *em, double *staticEm, double *sigma, double *auxSrc);
 
   /* CUDA GPU */
-  void *cuda_gkylMomentSrcTimeCenteredInit(int numBlocks, int numThreads);
+  /* Opaque structure holding CUBLAS library context */
+  struct cublasContext;
+  typedef struct cublasContext *cublasHandle_t;
+
+  typedef struct {
+    // TODO domain decomposition info
+    double *d_lhs;
+    double *d_rhs;
+    double **d_lhs_ptr;
+    double **d_rhs_ptr;
+    int *d_info;
+    cublasHandle_t handle;
+  } GkylMomentSrcDeviceCUBLAS_t;
+
+
+  GkylMomentSrcDeviceCUBLAS_t *cuda_gkylMomentSrcTimeCenteredInit(
+      int numBlocks, int numThreads);
   void momentSrcAdvanceOnDevicePreAlloc(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
-    double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld, void*);
+    double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
+    GkylMomentSrcDeviceCUBLAS_t *context);
   void momentSrcAdvanceOnDevice(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);

--- a/Updater/FiveMomentSrc.lua
+++ b/Updater/FiveMomentSrc.lua
@@ -211,9 +211,12 @@ function FiveMomentSrc:initDevice(tbl)
    -- yet; also numThreds could be different from actual values to be used
    self.first = true
 
+   -- callback into proxy.__gc when the proxy becomes free
+   -- FIXME Is this the correct way?
    local prox = newproxy(true)
    getmetatable(prox).__gc = function()
       ffi.C.cuda_gkylMomentSrcTimeCenteredDestroy(self.cublas_context)
+      self[prox] = true
    end
 end
 

--- a/Updater/FiveMomentSrc.lua
+++ b/Updater/FiveMomentSrc.lua
@@ -77,9 +77,6 @@ typedef struct {
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
     GkylMomentSrcDeviceCUBLAS_t *context);
-  void momentSrcAdvanceOnDevice(
-    int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
-    double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);
 ]]
 
 -- Explicit, SSP RK3 scheme

--- a/Updater/FiveMomentSrc.lua
+++ b/Updater/FiveMomentSrc.lua
@@ -166,15 +166,10 @@ function FiveMomentSrc:init(tbl)
    else
       assert(false, string.format("scheme %s not supported", scheme))
    end
-
-   if GKYL_HAVE_CUDA then
-      self:initDevice()
-      self.numThreads = tbl.numThreads or GKYL_DEFAULT_NUM_THREADS
-   end
 end
 
 
-function FiveMomentSrc:initDevice()
+function FiveMomentSrc:initDevice(tbl)
    local sz_sd = sizeof("MomentSrcData_t")
    self.sd_onDevice, err = cuda.Malloc(sz_sd)
    cuda.Memcpy(self.sd_onDevice, self._sd, sz_sd, cuda.MemcpyHostToDevice)
@@ -186,6 +181,8 @@ function FiveMomentSrc:initDevice()
 
    local sz_fluidFlds = sizeof("GkylCartField_t*") * self._sd.nFluids
    self.d_fluidFlds, err = cuda.Malloc(sz_fluidFlds)
+
+   self.numThreads = tbl.numThreads or GKYL_DEFAULT_NUM_THREADS
 end
 
 

--- a/Updater/FiveMomentSrcImpl.cpp
+++ b/Updater/FiveMomentSrcImpl.cpp
@@ -13,36 +13,13 @@
 #include <Eigen/Eigen>
 
 // Makes indexing cleaner
-static const unsigned X = 0;
-static const unsigned Y = 1;
-static const unsigned Z = 2;
-
 static const unsigned RHO = 0;
 static const unsigned MX = 1;
 static const unsigned MY = 2;
 static const unsigned MZ = 3;
 static const unsigned ER = 4;
 
-static const unsigned EX = 0;
-static const unsigned EY = 1;
-static const unsigned EZ = 2;
-static const unsigned BX = 3;
-static const unsigned BY = 4;
-static const unsigned BZ = 5;
-static const unsigned PHIE = 6;
-static const unsigned PHIM = 7;
-
 #define sq(x) ((x) * (x))
-#define cube(x) ((x) * (x) * (x))
-template <typename T> static T sgn(T val) {
-    return (T(0) < val) - (val < T(0));
-}
-
-static const int COL_PIV_HOUSEHOLDER_QR = 0;
-static const int PARTIAL_PIV_LU = 1;
-
-#define fidx(n, c) (3 * (n) + (c))
-#define eidx(c) (3 * nFluids + (c))
 
 void
 gkylFiveMomentSrcRk3(MomentSrcData_t *sd, FluidData_t *fd, double dt, double **ff, double *em, double *staticEm, double *sigma, double *auxSrc)

--- a/Updater/GkylMomentSrc.h
+++ b/Updater/GkylMomentSrc.h
@@ -20,10 +20,13 @@ extern "C" {
 
   GkylMomentSrcDeviceCUBLAS_t *cuda_gkylMomentSrcTimeCenteredInit(
       int numBlocks, int numThreads);
+  void cuda_gkylMomentSrcTimeCenteredDestroy(
+      GkylMomentSrcDeviceCUBLAS_t *context);
   void momentSrcAdvanceOnDevicePreAlloc(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
     GkylMomentSrcDeviceCUBLAS_t *context);
+
   void momentSrcAdvanceOnDevice(
       int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
       double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);

--- a/Updater/GkylMomentSrc.h
+++ b/Updater/GkylMomentSrc.h
@@ -2,15 +2,15 @@
 #ifndef GKYL_MOMENT_SRC_H
 #define GKYL_MOMENT_SRC_H
 
-#include <GkylCudaConfig.h>
 #include <MomentSrcCommon.h>
 #include <GkylCartField.h>
+#include <GkylCudaConfig.h>
+#include <cublas_v2.h>
 
 extern "C" {
-    /* CUDA GPU */
-    void momentSrcAdvanceOnDevice(
-        int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
-        double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);
+  void momentSrcAdvanceOnDevice(
+      int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
+      double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);
 }
 
 #endif // GKYL_MOMENT_SRC_H

--- a/Updater/GkylMomentSrc.h
+++ b/Updater/GkylMomentSrc.h
@@ -10,22 +10,24 @@
 extern "C" {
   typedef struct {
     // TODO domain decomposition info
+
+    // for time-centered scheme using cublas batched getrf and getrs
     double *d_lhs;
     double *d_rhs;
     double **d_lhs_ptr;
     double **d_rhs_ptr;
     int *d_info;
     cublasHandle_t handle;
-  } GkylMomentSrcDeviceCUBLAS_t;
+  } GkylMomentSrcDeviceData_t;
 
-  GkylMomentSrcDeviceCUBLAS_t *cuda_gkylMomentSrcTimeCenteredInit(
+  GkylMomentSrcDeviceData_t *cuda_gkylMomentSrcTimeCenteredInit(
       int numBlocks, int numThreads);
   void cuda_gkylMomentSrcTimeCenteredDestroy(
-      GkylMomentSrcDeviceCUBLAS_t *context);
+      GkylMomentSrcDeviceData_t *context);
   void momentSrcAdvanceOnDevicePreAlloc(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
-    GkylMomentSrcDeviceCUBLAS_t *context);
+    GkylMomentSrcDeviceData_t *context);
 }
 
 #endif // GKYL_MOMENT_SRC_H

--- a/Updater/GkylMomentSrc.h
+++ b/Updater/GkylMomentSrc.h
@@ -26,10 +26,6 @@ extern "C" {
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
     GkylMomentSrcDeviceCUBLAS_t *context);
-
-  void momentSrcAdvanceOnDevice(
-      int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
-      double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);
 }
 
 #endif // GKYL_MOMENT_SRC_H

--- a/Updater/GkylMomentSrc.h
+++ b/Updater/GkylMomentSrc.h
@@ -20,11 +20,11 @@ extern "C" {
     cublasHandle_t handle;
   } GkylMomentSrcDeviceData_t;
 
-  GkylMomentSrcDeviceData_t *cuda_gkylMomentSrcTimeCenteredInit(
+  GkylMomentSrcDeviceData_t *cuda_gkylMomentSrcInit(
       int numBlocks, int numThreads);
-  void cuda_gkylMomentSrcTimeCenteredDestroy(
+  void cuda_gkylMomentSrcDestroy(
       GkylMomentSrcDeviceData_t *context);
-  void momentSrcAdvanceOnDevicePreAlloc(
+  void momentSrcAdvanceOnDevice(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
     GkylMomentSrcDeviceData_t *context);

--- a/Updater/GkylMomentSrc.h
+++ b/Updater/GkylMomentSrc.h
@@ -21,13 +21,13 @@ extern "C" {
   } GkylMomentSrcDeviceData_t;
 
   GkylMomentSrcDeviceData_t *cuda_gkylMomentSrcInit(
-      int numBlocks, int numThreads);
-  void cuda_gkylMomentSrcDestroy(
-      GkylMomentSrcDeviceData_t *context);
+    const int nFluids, const int numBlocks, const int numThreads);
+  void cuda_gkylMomentSrcDestroy(GkylMomentSrcDeviceData_t *context);
   void momentSrcAdvanceOnDevice(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
     GkylMomentSrcDeviceData_t *context);
+  
 }
 
 #endif // GKYL_MOMENT_SRC_H

--- a/Updater/GkylMomentSrc.h
+++ b/Updater/GkylMomentSrc.h
@@ -8,6 +8,22 @@
 #include <cublas_v2.h>
 
 extern "C" {
+  typedef struct {
+    // TODO domain decomposition info
+    double *d_lhs;
+    double *d_rhs;
+    double **d_lhs_ptr;
+    double **d_rhs_ptr;
+    int *d_info;
+    cublasHandle_t handle;
+  } GkylMomentSrcDeviceCUBLAS_t;
+
+  // FIXME lua doesn't know cublasHandle_t; otherwise it is nicer to return
+  // GkylMomentSrcDeviceCUBLAS_t *
+  void *cuda_gkylMomentSrcTimeCenteredInit(int numBlocks, int numThreads);
+  void momentSrcAdvanceOnDevicePreAlloc(
+    int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
+    double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld, void*);
   void momentSrcAdvanceOnDevice(
       int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
       double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);

--- a/Updater/GkylMomentSrc.h
+++ b/Updater/GkylMomentSrc.h
@@ -13,31 +13,4 @@ extern "C" {
         double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);
 }
 
-#define cudacall(call)                                                                                                          \
-    do                                                                                                                          \
-    {                                                                                                                           \
-        cudaError_t err = (call);                                                                                               \
-        if(cudaSuccess != err)                                                                                                  \
-        {                                                                                                                       \
-            fprintf(stderr,"CUDA Error:\nFile = %s\nLine = %d\nReason = %s\n", __FILE__, __LINE__, cudaGetErrorString(err));    \
-            cudaDeviceReset();                                                                                                  \
-            exit(EXIT_FAILURE);                                                                                                 \
-        }                                                                                                                       \
-    }                                                                                                                           \
-    while (0)
-
-#define cublascall(call)                                                                                        \
-    do                                                                                                          \
-    {                                                                                                           \
-        cublasStatus_t status = (call);                                                                         \
-        if(CUBLAS_STATUS_SUCCESS != status)                                                                     \
-        {                                                                                                       \
-            fprintf(stderr,"CUBLAS Error:\nFile = %s\nLine = %d\nCode = %d\n", __FILE__, __LINE__, status);     \
-            cudaDeviceReset();                                                                                  \
-            exit(EXIT_FAILURE);                                                                                 \
-        }                                                                                                       \
-                                                                                                                \
-    }                                                                                                           \
-    while(0)
-
 #endif // GKYL_MOMENT_SRC_H

--- a/Updater/GkylMomentSrc.h
+++ b/Updater/GkylMomentSrc.h
@@ -18,12 +18,12 @@ extern "C" {
     cublasHandle_t handle;
   } GkylMomentSrcDeviceCUBLAS_t;
 
-  // FIXME lua doesn't know cublasHandle_t; otherwise it is nicer to return
-  // GkylMomentSrcDeviceCUBLAS_t *
-  void *cuda_gkylMomentSrcTimeCenteredInit(int numBlocks, int numThreads);
+  GkylMomentSrcDeviceCUBLAS_t *cuda_gkylMomentSrcTimeCenteredInit(
+      int numBlocks, int numThreads);
   void momentSrcAdvanceOnDevicePreAlloc(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
-    double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld, void*);
+    double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
+    GkylMomentSrcDeviceCUBLAS_t *context);
   void momentSrcAdvanceOnDevice(
       int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
       double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld);

--- a/Updater/MomentSrcCommon.cpp
+++ b/Updater/MomentSrcCommon.cpp
@@ -32,17 +32,18 @@ static const unsigned BZ = 5;
 static const unsigned PHIE = 6;
 static const unsigned PHIM = 7;
 
-#define sq(x) ((x) * (x))
-#define cube(x) ((x) * (x) * (x))
-template <typename T> static T sgn(T val) {
-    return (T(0) < val) - (val < T(0));
-}
+#define fidx(n, c) (3 * (n) + (c))
+#define eidx(c) (3 * nFluids + (c))
 
 static const int COL_PIV_HOUSEHOLDER_QR = 0;
 static const int PARTIAL_PIV_LU = 1;
 
-#define fidx(n, c) (3 * (n) + (c))
-#define eidx(c) (3 * nFluids + (c))
+#define sq(x) ((x) * (x))
+#define cube(x) ((x) * (x) * (x))
+
+template <typename T> inline static T sgn(T val) {
+    return (T(0) < val) - (val < T(0));
+}
 
 void
 gkylMomentSrcRk3(MomentSrcData_t *sd, FluidData_t *fd, double dt, double **ff, double *em, double *staticEm, double *sigma, double *auxSrc)

--- a/Updater/MomentSrcCommonDevice.cu
+++ b/Updater/MomentSrcCommonDevice.cu
@@ -1,9 +1,5 @@
-#include <cstdio>
 #include <GkylMomentSrc.h>
-#include <GkylCudaConfig.h>
-
-#include <cublas_v2.h>
-#include <cuda_runtime.h>
+#include <cstdio>
 
 // Makes indexing cleaner
 #define X (0)

--- a/Updater/MomentSrcCommonDevice.cu
+++ b/Updater/MomentSrcCommonDevice.cu
@@ -39,9 +39,9 @@ __global__ static void cuda_gkylMomentSrcSetPtrs(
 }
 
 
-GkylMomentSrcDeviceCUBLAS_t *cuda_gkylMomentSrcTimeCenteredInit(
+GkylMomentSrcDeviceData_t *cuda_gkylMomentSrcTimeCenteredInit(
     int numBlocks, int numThreads) {
-  GkylMomentSrcDeviceCUBLAS_t *context = new GkylMomentSrcDeviceCUBLAS_t[1];
+  GkylMomentSrcDeviceData_t *context = new GkylMomentSrcDeviceData_t[1];
   cublascall(cublasCreate(&(context->handle)));
 
   int batchSize = numThreads*numBlocks;
@@ -61,7 +61,7 @@ GkylMomentSrcDeviceCUBLAS_t *cuda_gkylMomentSrcTimeCenteredInit(
 
 
 void cuda_gkylMomentSrcTimeCenteredDestroy(
-    GkylMomentSrcDeviceCUBLAS_t *context) {
+    GkylMomentSrcDeviceData_t *context) {
   cudacall(cudaFree(context->d_lhs_ptr));
   cudacall(cudaFree(context->d_rhs_ptr));
   cudacall(cudaFree(context->d_lhs));
@@ -213,7 +213,7 @@ __global__ static void cuda_gkylMomentSrcTimeCenteredSetMat(
 static void cuda_gkylMomentSrcTimeCenteredPreAlloc(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
-    GkylMomentSrcDeviceCUBLAS_t *context) {
+    GkylMomentSrcDeviceData_t *context) {
   double **d_lhs_ptr = context->d_lhs_ptr;
   double **d_rhs_ptr = context->d_rhs_ptr;
   int *d_info = context->d_info;
@@ -258,7 +258,7 @@ static void cuda_gkylMomentSrcTimeCenteredPreAlloc(
 void momentSrcAdvanceOnDevicePreAlloc(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld,
-    GkylMomentSrcDeviceCUBLAS_t *context)
+    GkylMomentSrcDeviceData_t *context)
 {
   cuda_gkylMomentSrcTimeCenteredPreAlloc(
       numBlocks, numThreads, sd, fd, dt, fluidFlds, emFld, context);

--- a/Updater/MomentSrcCommonDevice.cu
+++ b/Updater/MomentSrcCommonDevice.cu
@@ -157,6 +157,9 @@ __global__ void cuda_gkylMomentSrcSetMat(
   d_lhs_ptr[linearIdx] = lhs;
   d_rhs_ptr[linearIdx] = rhs;
 
+  for (int c=0; c<N*N; c++)
+    lhs[c] = 0;
+
   unsigned nFluids = sd->nFluids;
   double dt1 = 0.5 * dt;
   double dt2 = 0.5 * dt / sd->epsilon0;

--- a/Updater/MomentSrcCommonDevice.cu
+++ b/Updater/MomentSrcCommonDevice.cu
@@ -176,7 +176,6 @@ static cudaError_t cuda_gkylMomentSrcTimeCentered(
     int numBlocks, int numThreads, MomentSrcData_t *sd, FluidData_t *fd,
     double dt, GkylCartField_t **fluidFlds, GkylCartField_t *emFld) {
   // FIXME save d_lhs and avoid reallocating?
-  cublasStatus_t status;
   double *d_lhs = 0;
   double *d_rhs = 0;
   double **d_lhs_ptr = 0;

--- a/Updater/MomentSrcCommonDevice.cu
+++ b/Updater/MomentSrcCommonDevice.cu
@@ -2,31 +2,31 @@
 #include <cstdio>
 
 // Makes indexing cleaner
-#define X (0)
-#define Y (1)
-#define Z (2)
+static const unsigned X = 0;
+static const unsigned Y = 1;
+static const unsigned Z = 2;
 
-#define RHO (0)
-#define MX (1)
-#define MY (2)
-#define MZ (3)
-#define ER (4)
+static const unsigned RHO = 0;
+static const unsigned MX = 1;
+static const unsigned MY = 2;
+static const unsigned MZ = 3;
+static const unsigned ER = 4;
 
-#define EX (0)
-#define EY (1)
-#define EZ (2)
-#define BX (3)
-#define BY (4)
-#define BZ (5)
-#define PHIE (6)
-#define PHIM (7)
+static const unsigned EX = 0;
+static const unsigned EY = 1;
+static const unsigned EZ = 2;
+static const unsigned BX = 3;
+static const unsigned BY = 4;
+static const unsigned BZ = 5;
+static const unsigned PHIE = 6;
+static const unsigned PHIM = 7;
 
 #define fidx(n, c) (3 * (n) + (c))
 #define eidx(c) (3 * nFluids + (c))
 
-#define N (9)
 #define sq(x) ((x) * (x))
 
+#define N (9)
 #define F2(base,i,j) (base)[(j)*N+(i)]
 
 

--- a/Updater/MomentSrcCommonDevice.cu
+++ b/Updater/MomentSrcCommonDevice.cu
@@ -189,17 +189,13 @@ static cudaError_t cuda_gkylMomentSrcTimeCentered(
   cublascall(cublasCreate(&handle));
 
   // memory for actuall arrays and vectors
-  cudacall(cudaMalloc(
-        reinterpret_cast<void **>(&d_lhs), batchSize*N*N*sizeof(double)));
-  cudacall(cudaMalloc(
-        reinterpret_cast<void **>(&d_rhs), batchSize*N*sizeof(double)));
-  cudacall(cudaMalloc(
-        reinterpret_cast<void **>(&d_info), batchSize*sizeof(int)));
+  cudacall(cudaMalloc(&d_lhs, batchSize*N*N*sizeof(double)));
+  cudacall(cudaMalloc(&d_rhs, batchSize*N*sizeof(double)));
+  cudacall(cudaMalloc(&d_info, batchSize*sizeof(int)));
 
   // memory for pointers to the actuall arrays and vectors
-  cudacall(cudaMalloc<double*>((&d_lhs_ptr), batchSize*sizeof(double*)));
-  cudacall(cudaMalloc(
-        reinterpret_cast<void **>(&d_rhs_ptr), batchSize*sizeof(double*)));
+  cudacall(cudaMalloc(&d_lhs_ptr, batchSize*sizeof(double*)));
+  cudacall(cudaMalloc(&d_rhs_ptr, batchSize*sizeof(double*)));
 
   cuda_gkylMomentSrcSetMat<<<numBlocks, numThreads>>>(
       sd, fd, dt, fluidFlds, emFld, d_lhs, d_rhs, d_lhs_ptr, d_rhs_ptr);

--- a/Updater/TenMomentSrcImpl.cpp
+++ b/Updater/TenMomentSrcImpl.cpp
@@ -13,10 +13,6 @@
 #include <Eigen/Eigen>
 
 // Makes indexing cleaner
-static const unsigned X = 0;
-static const unsigned Y = 1;
-static const unsigned Z = 2;
-
 static const unsigned RHO = 0;
 static const unsigned MX = 1;
 static const unsigned MY = 2;
@@ -29,14 +25,9 @@ static const unsigned P22 = 7;
 static const unsigned P23 = 8;
 static const unsigned P33 = 9;
 
-static const unsigned EX = 0;
-static const unsigned EY = 1;
-static const unsigned EZ = 2;
 static const unsigned BX = 3;
 static const unsigned BY = 4;
 static const unsigned BZ = 5;
-static const unsigned PHIE = 6;
-static const unsigned PHIM = 7;
 
 static const int COL_PIV_HOUSEHOLDER_QR = 0;
 static const int PARTIAL_PIV_LU = 1;

--- a/Updater/WavePropagation.lua
+++ b/Updater/WavePropagation.lua
@@ -241,15 +241,9 @@ function WavePropagation:init(tbl)
    self._rescaleWave = loadstring( rescaleWaveTempl {MEQN = meqn} )()
    self._secondOrderFlux = loadstring( secondOrderFluxTempl {MEQN = meqn} )()
    self._secondOrderUpdate = loadstring( secondOrderUpdateTempl {MEQN = meqn} )()
-
-   if GKYL_HAVE_CUDA then
-      self:initDevice()
-      self.numThreads = tbl.numThreads or GKYL_DEFAULT_NUM_THREADS
-      self._useSharedDevice = xsys.pickBool(tbl.useSharedDevice, false)
-   end
 end
 
-function WavePropagation:initDevice()
+function WavePropagation:initDevice(tbl)
    self.dtByCell = DataStruct.Field {
       onGrid = self._onGrid,
       numComponents = 1,
@@ -268,6 +262,9 @@ function WavePropagation:initDevice()
    local sz = sizeof("GkylWavePropagation_t")
    self._onDevice, err = cuda.Malloc(sz)
    cuda.Memcpy(self._onDevice, hyper, sz, cuda.MemcpyHostToDevice)
+
+   self.numThreads = tbl.numThreads or GKYL_DEFAULT_NUM_THREADS
+   self._useSharedDevice = xsys.pickBool(tbl.useSharedDevice, false)
 end
 
 -- Limit waves: this code closely follows the example of CLAWPACK and


### PR DESCRIPTION
- w.i.p. but now with timing benchmark in the unit test
  - time-centered update
  - copy costs are ignored
  - gpu cuBLAS batched `getrf`/`getrs` vs cpu `Eigen` `lhs.partialPivLu`
    - for `nx=8192`, speedup ~ 70x
    - for 'nx=32768`, speedup ~ 40x
  - the speedup is __NOT__  ideal
    - Simple profiling shows the main cost is in setting the `lhs` and `rhs` arrays that live in the global memory

- Two generic macros `cudacall` and `cublascall` that checks error returned from cuda and cublas calls.

#### Next?
- still need to try to use cuSolver's unbatched functions
- implement the `direct` solver
  - reusing the Eigen implementation for vector container that allows algebraic operations
    - include Eigen header; use Eigen in wscript
    - seems to compile
    - warning that older Eigen is using deprecated header (ignore? upgrade Eigen?)