### PR TITLE
Changes to recovery so it works in higher dimensions/phase space

### DIFF
--- a/cas-scripts/recovery-calc/recovery-1cell.mac
+++ b/cas-scripts/recovery-calc/recovery-1cell.mac
@@ -29,7 +29,7 @@ calcRecov1CellGen(basisNm, recDir, dirs, polyOrder, C, lo, ce, up) := block(
   baLo1D, baCe1D, baUp1D, baLoND, baCeND, baUpND,
   dimProjLo, dimProjCe, dimProjUp, qLo1D, qCe1D, qUp1D,
   wx, wy, wz,
-  numDims, dirSubList
+  numDims
   ],
 
   baCe1D : getBasis(basisNm, [x], polyOrder),
@@ -107,11 +107,8 @@ calcRecov1CellGen(basisNm, recDir, dirs, polyOrder, C, lo, ce, up) := block(
   numDims : length(dirs),
   if numDims > 1 then (
     baCeND : getBasis(basisNm, dirs, polyOrder),
-    dirSubList : if numDims=2 then
-                   [wx=dirs[1], wy=dirs[2]]
-                 else
-                   [wx=dirs[1], wy=dirs[2], wz=dirs[3]],
-    baCeND : subst(dirSubList, subst([x=wx,y=wy,z=wz], baCeND)),  
+    baVars : listofvars(baCeND),
+    baCeND : subst(makelist(baVars[i]=dirs[i],i,1,numDims), baCeND),
     baLoND : etaDir(recDir, -2, 2, baCeND),
     baUpND : etaDir(recDir, 2, 2, baCeND),
     

--- a/cas-scripts/recovery-calc/recovery-1cell.mac
+++ b/cas-scripts/recovery-calc/recovery-1cell.mac
@@ -32,7 +32,7 @@ calcRecov1CellGen(basisNm, recDir, dirs, polyOrder, C, lo, ce, up) := block(
   numDims, dirSubList
   ],
 
-  baCe1D : getBasis(sconcat("basis-precalc/basis", basisNm, "1x"), polyOrder),
+  baCe1D : getBasis(basisNm, 1, polyOrder),
   baCe1D : subst(x=recDir, baCe1D),
   baLo1D : etaDir(recDir, -2, 2, baCe1D),
   baUp1D : etaDir(recDir, 2, 2, baCe1D),
@@ -106,8 +106,7 @@ calcRecov1CellGen(basisNm, recDir, dirs, polyOrder, C, lo, ce, up) := block(
   /* Backsubstitute the non-recovered directtions if needed */
   numDims : length(dirs),
   if numDims > 1 then (
-    baCeND : getBasis(sconcat("basis-precalc/basis", basisNm, numDims, "x"),
-      polyOrder),
+    baCeND : getBasis(basisNm, numDims, polyOrder),
     dirSubList : if numDims=2 then
                    [wx=dirs[1], wy=dirs[2]]
                  else

--- a/cas-scripts/recovery-calc/recovery-1cell.mac
+++ b/cas-scripts/recovery-calc/recovery-1cell.mac
@@ -32,7 +32,7 @@ calcRecov1CellGen(basisNm, recDir, dirs, polyOrder, C, lo, ce, up) := block(
   numDims, dirSubList
   ],
 
-  baCe1D : getBasis(basisNm, 1, polyOrder),
+  baCe1D : getBasis(basisNm, [x], polyOrder),
   baCe1D : subst(x=recDir, baCe1D),
   baLo1D : etaDir(recDir, -2, 2, baCe1D),
   baUp1D : etaDir(recDir, 2, 2, baCe1D),
@@ -106,7 +106,7 @@ calcRecov1CellGen(basisNm, recDir, dirs, polyOrder, C, lo, ce, up) := block(
   /* Backsubstitute the non-recovered directtions if needed */
   numDims : length(dirs),
   if numDims > 1 then (
-    baCeND : getBasis(basisNm, numDims, polyOrder),
+    baCeND : getBasis(basisNm, dirs, polyOrder),
     dirSubList : if numDims=2 then
                    [wx=dirs[1], wy=dirs[2]]
                  else

--- a/cas-scripts/recovery-calc/recovery-2cell.mac
+++ b/cas-scripts/recovery-calc/recovery-2cell.mac
@@ -28,7 +28,7 @@ calcRecov2CellGen(basisNm, recDir, dirs, polyOrder, lo, up) := block(
   baLo1D, baCe1D, baUp1D, baLoND, baCeND, baUpND,
   dimProjLo, dimProjUp, qLo1D, qUp1D,
   wx, wy, wz,
-  numDims, dirSubList
+  numDims
   ],
   
   baCe1D : getBasis(basisNm, [x], polyOrder),
@@ -106,17 +106,17 @@ calcRecov2CellGen(basisNm, recDir, dirs, polyOrder, lo, up) := block(
   numDims : length(dirs),
   if numDims > 1 then (
     baCeND : getBasis(basisNm, dirs, polyOrder),
-    dirSubList : makelist(w[i]=dirs[i], i, 1, numDims),
-    baCeND : subst(dirSubList, subst([x=w[1],y=w[2],z=w[3]], baCeND)),  
+    baVars : listofvars(baCeND),
+    baCeND : subst(makelist(baVars[i]=dirs[i],i,1,numDims), baCeND),  
     baLoND : etaDir(recDir, -1, 2, baCeND),
     baUpND : etaDir(recDir, 1, 2, baCeND),
     /* prepare for the case where expansion coefficients at a wall are
     given; i.e., a basis function set with one less dimension is
     needed */
     perpDirs : delete(recDir, dirs),
-    baCeNDw : getBasis(basisNm, perpDirs, polyOrder),
-    dirSubList : makelist(w[i]=perpDirs[i], i, 1, numDims-1),
-    baCeNDw : subst(dirSubList, subst([x=w[1],y=w[2]], baCeNDw)), 
+    baCeNDw  : getBasis(basisNm, delete(dirs[numDims], dirs), polyOrder),
+    baVars   : listofvars(baCeNDw),
+    baCeNDw  : subst(makelist(baVars[i]=perpDirs[i],i,1,numDims-1), baCeNDw), 
     
     projSubList : [],
     if is(op(lo)=dg) then (

--- a/cas-scripts/recovery-calc/recovery-2cell.mac
+++ b/cas-scripts/recovery-calc/recovery-2cell.mac
@@ -31,7 +31,7 @@ calcRecov2CellGen(basisNm, recDir, dirs, polyOrder, lo, up) := block(
   numDims, dirSubList
   ],
   
-  baCe1D : getBasis(basisNm, 1, polyOrder),
+  baCe1D : getBasis(basisNm, [x], polyOrder),
   baCe1D : subst(x=recDir, baCe1D),
   baLo1D : etaDir(recDir, -1, 2, baCe1D),
   baUp1D : etaDir(recDir, 1, 2, baCe1D),
@@ -105,7 +105,7 @@ calcRecov2CellGen(basisNm, recDir, dirs, polyOrder, lo, up) := block(
   /* backsubstitute the non-recovered directtions if needed */
   numDims : length(dirs),
   if numDims > 1 then (
-    baCeND : getBasis(basisNm, numDims, polyOrder),
+    baCeND : getBasis(basisNm, dirs, polyOrder),
     dirSubList : makelist(w[i]=dirs[i], i, 1, numDims),
     baCeND : subst(dirSubList, subst([x=w[1],y=w[2],z=w[3]], baCeND)),  
     baLoND : etaDir(recDir, -1, 2, baCeND),
@@ -114,7 +114,7 @@ calcRecov2CellGen(basisNm, recDir, dirs, polyOrder, lo, up) := block(
     given; i.e., a basis function set with one less dimension is
     needed */
     perpDirs : delete(recDir, dirs),
-    baCeNDw : getBasis(basisNm, numDims-1, polyOrder),
+    baCeNDw : getBasis(basisNm, perpDirs, polyOrder),
     dirSubList : makelist(w[i]=perpDirs[i], i, 1, numDims-1),
     baCeNDw : subst(dirSubList, subst([x=w[1],y=w[2]], baCeNDw)), 
     

--- a/cas-scripts/recovery-calc/recovery-2cell.mac
+++ b/cas-scripts/recovery-calc/recovery-2cell.mac
@@ -31,7 +31,7 @@ calcRecov2CellGen(basisNm, recDir, dirs, polyOrder, lo, up) := block(
   numDims, dirSubList
   ],
   
-  baCe1D : getBasis(sconcat("basis-precalc/basis", basisNm, "1x"), polyOrder),
+  baCe1D : getBasis(basisNm, 1, polyOrder),
   baCe1D : subst(x=recDir, baCe1D),
   baLo1D : etaDir(recDir, -1, 2, baCe1D),
   baUp1D : etaDir(recDir, 1, 2, baCe1D),
@@ -105,8 +105,7 @@ calcRecov2CellGen(basisNm, recDir, dirs, polyOrder, lo, up) := block(
   /* backsubstitute the non-recovered directtions if needed */
   numDims : length(dirs),
   if numDims > 1 then (
-    baCeND : getBasis(sconcat("basis-precalc/basis", basisNm, numDims, "x"),
-      polyOrder),
+    baCeND : getBasis(basisNm, numDims, polyOrder),
     dirSubList : makelist(w[i]=dirs[i], i, 1, numDims),
     baCeND : subst(dirSubList, subst([x=w[1],y=w[2],z=w[3]], baCeND)),  
     baLoND : etaDir(recDir, -1, 2, baCeND),
@@ -115,8 +114,7 @@ calcRecov2CellGen(basisNm, recDir, dirs, polyOrder, lo, up) := block(
     given; i.e., a basis function set with one less dimension is
     needed */
     perpDirs : delete(recDir, dirs),
-    baCeNDw : getBasis(sconcat("basis-precalc/basis", basisNm, numDims-1, "x"),
-      polyOrder),
+    baCeNDw : getBasis(basisNm, numDims-1, polyOrder),
     dirSubList : makelist(w[i]=perpDirs[i], i, 1, numDims-1),
     baCeNDw : subst(dirSubList, subst([x=w[1],y=w[2]], baCeNDw)), 
     

--- a/cas-scripts/recovery-calc/recovery-3cell.mac
+++ b/cas-scripts/recovery-calc/recovery-3cell.mac
@@ -29,7 +29,7 @@ calcRecov3CellGen(basisNm, recDir, dirs, polyOrder, lo, ce, up) := block(
   baLo1D, baCe1D, baUp1D, baLoND, baCeND, baUpND,
   dimProjLo, dimProjCe, dimProjUp, qLo1D, qCe1D, qUp1D,
   wx, wy, wz,
-  numDims, dirSubList
+  numDims
   ],
   
   baCe1D : getBasis(basisNm, [x], polyOrder),
@@ -113,11 +113,8 @@ calcRecov3CellGen(basisNm, recDir, dirs, polyOrder, lo, ce, up) := block(
   numDims : length(dirs),
   if numDims > 1 then (
     baCeND : getBasis(basisNm, dirs, polyOrder),
-    dirSubList : if numDims=2 then
-                   [wx=dirs[1], wy=dirs[2]]
-                 else
-                 [wx=dirs[1], wy=dirs[2], wz=dirs[3]],
-    baCeND : subst(dirSubList, subst([x=wx,y=wy,z=wz], baCeND)),
+    baVars : listofvars(baCeND),
+    baCeND : subst(makelist(baVars[i]=dirs[i],i,1,numDims), baCeND),
     baLoND : etaDir(recDir, -2, 2, baCeND),
     baUpND : etaDir(recDir, 2, 2, baCeND),
 

--- a/cas-scripts/recovery-calc/recovery-3cell.mac
+++ b/cas-scripts/recovery-calc/recovery-3cell.mac
@@ -32,7 +32,7 @@ calcRecov3CellGen(basisNm, recDir, dirs, polyOrder, lo, ce, up) := block(
   numDims, dirSubList
   ],
   
-  baCe1D : getBasis(basisNm, 1, polyOrder),
+  baCe1D : getBasis(basisNm, [x], polyOrder),
   baCe1D : subst(x=recDir, baCe1D),
   baLo1D : etaDir(recDir, -2, 2, baCe1D),
   baUp1D : etaDir(recDir, 2, 2, baCe1D),
@@ -112,7 +112,7 @@ calcRecov3CellGen(basisNm, recDir, dirs, polyOrder, lo, ce, up) := block(
   /* backsubstitute the non-recovered directtions if needed */
   numDims : length(dirs),
   if numDims > 1 then (
-    baCeND : getBasis(basisNm, numDims, polyOrder),
+    baCeND : getBasis(basisNm, dirs, polyOrder),
     dirSubList : if numDims=2 then
                    [wx=dirs[1], wy=dirs[2]]
                  else

--- a/cas-scripts/recovery-calc/recovery-3cell.mac
+++ b/cas-scripts/recovery-calc/recovery-3cell.mac
@@ -32,7 +32,7 @@ calcRecov3CellGen(basisNm, recDir, dirs, polyOrder, lo, ce, up) := block(
   numDims, dirSubList
   ],
   
-  baCe1D : getBasis(sconcat("basis-precalc/basis", basisNm, "1x"), polyOrder),
+  baCe1D : getBasis(basisNm, 1, polyOrder),
   baCe1D : subst(x=recDir, baCe1D),
   baLo1D : etaDir(recDir, -2, 2, baCe1D),
   baUp1D : etaDir(recDir, 2, 2, baCe1D),
@@ -112,7 +112,7 @@ calcRecov3CellGen(basisNm, recDir, dirs, polyOrder, lo, ce, up) := block(
   /* backsubstitute the non-recovered directtions if needed */
   numDims : length(dirs),
   if numDims > 1 then (
-    baCeND : getBasis(sconcat("basis-precalc/basis", basisNm, numDims, "x"), polyOrder),
+    baCeND : getBasis(basisNm, numDims, polyOrder),
     dirSubList : if numDims=2 then
                    [wx=dirs[1], wy=dirs[2]]
                  else

--- a/cas-scripts/recovery-calc/recovery-face.mac
+++ b/cas-scripts/recovery-calc/recovery-face.mac
@@ -5,17 +5,14 @@ calcRecovFaceGen(basisNm, recDirs, dirs, face, polyOrder, C, lo, ce, up) := bloc
   rLoCoef, rCeCoef, rUpCoef, r,
   lo2, ce2, up2,
   wx, wy,
-  numDims, dirSubList
+  numDims
   ],
 
-  numDims : length(dirs),
+  numDims  : length(dirs),
   perpDirs : delete(recDirs[1], dirs),
-  ba : getBasis(basisNm, perpDirs, polyOrder),
-  dirSubList : if numDims=2 then
-                 [wx=perpDirs[1]]
-               else
-                 [wx=perpDirs[1], wy=perpDirs[2]],
-  ba : subst(dirSubList, subst([x=wx, y=wy], ba)),
+  ba       : getBasis(basisNm, delete(dirs[numDims], dirs), polyOrder),
+  baVars   : listofvars(ba),
+  ba       : subst(makelist(baVars[i]=perpDirs[i],i,1,numDims-1), ba),  
 
   if is(op(lo)=dg) then (
     rLo : calcRecov2CellGen(basisNm, recDirs[1], dirs, polyOrder,

--- a/cas-scripts/recovery-calc/recovery-face.mac
+++ b/cas-scripts/recovery-calc/recovery-face.mac
@@ -10,7 +10,7 @@ calcRecovFaceGen(basisNm, recDirs, dirs, face, polyOrder, C, lo, ce, up) := bloc
 
   numDims : length(dirs),
   perpDirs : delete(recDirs[1], dirs),
-  ba : getBasis(basisNm, numDims-1, polyOrder),
+  ba : getBasis(basisNm, perpDirs, polyOrder),
   dirSubList : if numDims=2 then
                  [wx=perpDirs[1]]
                else

--- a/cas-scripts/recovery-calc/recovery-face.mac
+++ b/cas-scripts/recovery-calc/recovery-face.mac
@@ -10,8 +10,7 @@ calcRecovFaceGen(basisNm, recDirs, dirs, face, polyOrder, C, lo, ce, up) := bloc
 
   numDims : length(dirs),
   perpDirs : delete(recDirs[1], dirs),
-  ba : getBasis(sconcat("basis-precalc/basis", basisNm, numDims-1, "x"),
-    polyOrder),
+  ba : getBasis(basisNm, numDims-1, polyOrder),
   dirSubList : if numDims=2 then
                  [wx=perpDirs[1]]
                else

--- a/cas-scripts/recovery.mac
+++ b/cas-scripts/recovery.mac
@@ -46,19 +46,30 @@ getBasis(basisType, varsIn, polyOrder) := block(
       vDim : vDim+1
     )
   ),
-  if (vDim = 0) then (
+  dimTot       : cDim+vDim,
+  useConfBasis : true,
+  if (dimTot # length(varsIn)) then (
+    /* Using variables other than x,y,z,vx,vy,vz. */
+    if (dimTot < 4) then (
+      load(sconcat("basis-precalc/basis", basisType, dimTot, "x"))
+    ) else (
+      useConfBasis : false,
+      load(sconcat("basis-precalc/basis", basisType, dimTot-3, "x", 3, "v"))
+    )
+  ) else if (vDim = 0) then (
     load(sconcat("basis-precalc/basis", basisType, cDim, "x"))
   ) else (
+    useConfBasis : false,
     load(sconcat("basis-precalc/basis", basisType, cDim, "x", vDim, "v"))
   ),
   if polyOrder > 0 then (
-    if (vDim = 0) then (
+    if useConfBasis then (
       return(basisC[polyOrder])
     ) else (
       return(basisP[polyOrder])
     )
   ) else (
-    if (vDim = 0) then (
+    if useConfBasis then (
       return([basisC[1][1]])
     ) else (
       return([basisP[1][1]])

--- a/cas-scripts/recovery.mac
+++ b/cas-scripts/recovery.mac
@@ -32,21 +32,33 @@ getDirIdx(dir, numDims) := block([],
   if dir = z then return(3)
 ) $
 
-getBasis(basisType, dimTot, polyOrder) := block(
-  [varsC, basisC, varsP, basisP],
-  if (dimTot < 4) then (
-    load(sconcat("basis-precalc/basis", basisType, dimTot, "x"))
+getBasis(basisType, varsIn, polyOrder) := block(
+  [varsC, basisC, varsP, basisP, cDim, vDim, confVars, velVars],
+  /* Determine dimensionality from a list of variables. */
+  confVars : [x,y,z],
+  velVars  : [vx,vy,vz],
+  cDim     : 0,
+  vDim     : 0,
+  for v in varsIn do (
+    if (length(sublist_indices(confVars,lambda([a],a=v))) > 0) then (
+      cDim : cDim+1
+    ) else if (length(sublist_indices(velVars,lambda([a],a=v))) > 0) then (
+      vDim : vDim+1
+    )
+  ),
+  if (vDim = 0) then (
+    load(sconcat("basis-precalc/basis", basisType, cDim, "x"))
   ) else (
-    load(sconcat("basis-precalc/basis", basisType, dimTot-3, "x", 3, "v"))
+    load(sconcat("basis-precalc/basis", basisType, cDim, "x", vDim, "v"))
   ),
   if polyOrder > 0 then (
-    if (dimTot < 4) then (
+    if (vDim = 0) then (
       return(basisC[polyOrder])
     ) else (
       return(basisP[polyOrder])
     )
   ) else (
-    if (dimTot < 4) then (
+    if (vDim = 0) then (
       return([basisC[1][1]])
     ) else (
       return([basisP[1][1]])

--- a/cas-scripts/recovery.mac
+++ b/cas-scripts/recovery.mac
@@ -32,14 +32,25 @@ getDirIdx(dir, numDims) := block([],
   if dir = z then return(3)
 ) $
 
-getBasis(name, polyOrder) := block(
-  [varsC, basisC, basisConstant],
-  load(name),
+getBasis(basisType, dimTot, polyOrder) := block(
+  [varsC, basisC, varsP, basisP],
+  if (dimTot < 4) then (
+    load(sconcat("basis-precalc/basis", basisType, dimTot, "x"))
+  ) else (
+    load(sconcat("basis-precalc/basis", basisType, dimTot-3, "x", 3, "v"))
+  ),
   if polyOrder > 0 then (
-    return(basisC[polyOrder])
-  )
-  else (
-    return([basisC[1][1]])
+    if (dimTot < 4) then (
+      return(basisC[polyOrder])
+    ) else (
+      return(basisP[polyOrder])
+    )
+  ) else (
+    if (dimTot < 4) then (
+      return([basisC[1][1]])
+    ) else (
+      return([basisP[1][1]])
+    )
   )
 ) $
 


### PR DESCRIPTION
The changes primarily deal with how a basis is loaded, and we construct the perpendicular basis.

Could the reviewer (e.g. Petr) please confirm or help me confirm that this didn't break anything (in for example the FPO or DiscontPoisson kernels)?