### PR TITLE
Nonuniform recovery fix

### DIFF
--- a/cas-scripts/recovery-calc/recovery-1cell.mac
+++ b/cas-scripts/recovery-calc/recovery-1cell.mac
@@ -117,9 +117,9 @@ calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxu
     ba : psubst(makelist(baVars[i]=dirs[i],i,1,numDims), ba),
     /* rescale basis */
     shiftList : makelist(0, i, 1, numDims),
-    baLoND : eta(shiftList, dxlo, ba),
-    baCeND : eta(shiftList, dxce, ba),
-    baUpND : eta(shiftList, dxup, ba),
+    baLoND : eta(dirs, shiftList, dxlo, ba),
+    baCeND : eta(dirs, shiftList, dxce, ba),
+    baUpND : eta(dirs, shiftList, dxup, ba),
     /* shift basis */
     baLoND : etaDir(recDir, -dxce[recDirIdx]/2-dxlo[recDirIdx]/2, 2, baLoND),
     baUpND : etaDir(recDir, dxce[recDirIdx]/2+dxup[recDirIdx]/2, 2, baUpND),

--- a/cas-scripts/recovery-calc/recovery-2cell.mac
+++ b/cas-scripts/recovery-calc/recovery-2cell.mac
@@ -194,7 +194,7 @@ calcRecov2CellGenNonuniform(basisNm, recDir, dirs, polyOrder, dxlo, dxup, lo, up
     
     projSubList : [],
     if is(op(lo)=dg) then (
-      dimProjLo : calcInnerProdListGen([recDir], [[-dxlo[recDirIdx], 0]],
+      dimProjLo : (2/dxlo[recDirIdx])*calcInnerProdListGen([recDir], [[-dxlo[recDirIdx], 0]],
         1, baLo1D, doExpand(args(lo)[1], baLoND)),
       projSubList : append (
         projSubList,
@@ -211,7 +211,7 @@ calcRecov2CellGenNonuniform(basisNm, recDir, dirs, polyOrder, dxlo, dxup, lo, up
       )
     ),
     if is(op(up)=dg) then (
-      dimProjUp : calcInnerProdListGen([recDir], [[0, dxup[recDirIdx]]],
+      dimProjUp : (2/dxup[recDirIdx])*calcInnerProdListGen([recDir], [[0, dxup[recDirIdx]]],
         1, baUp1D, doExpand(args(up)[1], baUpND)),
       projSubList : append (
         projSubList,

--- a/cas-scripts/recovery-calc/recovery-2cell.mac
+++ b/cas-scripts/recovery-calc/recovery-2cell.mac
@@ -179,8 +179,8 @@ calcRecov2CellGenNonuniform(basisNm, recDir, dirs, polyOrder, dxlo, dxup, lo, up
     baCeND : psubst(makelist(baVars[i]=dirs[i],i,1,numDims), baCeND),
     /* rescale basis */
     shiftList : makelist(0, i, 1, numDims),
-    baLoND : eta(shiftList, dxlo, baCeND),
-    baUpND : eta(shiftList, dxup, baCeND),
+    baLoND : eta(dirs, shiftList, dxlo, baCeND),
+    baUpND : eta(dirs, shiftList, dxup, baCeND),
     /* shift basis */
     baLoND : etaDir(recDir, -dxlo[recDirIdx]/2, 2, baLoND),
     baUpND : etaDir(recDir, dxup[recDirIdx]/2, 2, baUpND),

--- a/cas-scripts/recovery.mac
+++ b/cas-scripts/recovery.mac
@@ -13,14 +13,13 @@ etaDir(dir, xc, dx, fn) := block(
   return(subst(td=dir, subst(dir=2*(td-xc)/dx, fn)))
 ) $
 
-eta(xc, dx, fn) := block(
+eta(vars, xc, dx, fn) := block([out],
   /* A helper function to shift basis functions in all directions
      together
      Example: eta([dx/2, -dy/2], [dx, dy], fn) */
-  [out, tx, ty, tz],
-  out : subst(tx=x, subst(x=2*(tx-xc[1])/dx[1], fn)),
-  if length(dx) > 1 then out : subst(ty=y, subst(y=2*(ty-xc[2])/dx[2], out)),
-  if length(dx) > 2 then out : subst(tz=z, subst(z=2*(tz-xc[3])/dx[3], out)),
+  out : etaDir(vars[1], xc[1], dx[1], fn),
+  if length(dx) > 1 then out : etaDir(vars[2], xc[2], dx[2], out),
+  if length(dx) > 2 then out : etaDir(vars[3], xc[3], dx[3], out),
   return(out)
 ) $
 


### PR DESCRIPTION
See the comments for the 2 commits in this branch. Basically:

1. Insert a (2/dx) factor in the projection of the function onto the 1D basis along the recovery direction, which gets substituted into the 1D recovery poly. I don't fully understand why this is needed but seems to do the trick.
2. Change `eta` in recovery.mac so that it does not assume that the variables are x,y,z. Now `eta` takes the variable list as an input. I also don't understand why this wasn't an issue for VmLBO or GkLBO before, perhaps because with dx=2 this function doesn't do much in recovery-2cell. Also, perhaps eta should loop over the number of dimensions instead of just doing the replacement for dirs 1, 2 and 3. What if dim=5?

Recovery unit test passes in this branch.