### PR TITLE
Dissociate the MomentSpecies app from the FluidSpecies app

### DIFF
--- a/App/PlasmaOnCartGrid.lua
+++ b/App/PlasmaOnCartGrid.lua
@@ -1043,15 +1043,15 @@ return {
    Moments = function ()
       App.label = "Multi-fluid"
       return {
-	 App = App,
-	 Species = require "App.Species.MomentSpecies",
-	 Field = require ("App.Field.MaxwellField").MaxwellField,
-	 CollisionlessEmSource = require "App.FluidSources.CollisionlessEmSource",
-	 TenMomentRelaxSource  = require "App.FluidSources.TenMomentRelaxSource",
-        AxisymmetricMomentSource = require "App.FluidSources.AxisymmetricMomentSource",
-        AxisymmetricPhMaxwellSource = require "App.FluidSources.AxisymmetricPhMaxwellSource",
-        BraginskiiHeatConductionSource = require "App.FluidSources.BraginskiiHeatConductionSource",
-        BraginskiiViscosityDiffusionSource = require "App.FluidSources.BraginskiiViscosityDiffusionSource",
+         App = App,
+         Species = require "App.Species.MomentSpecies",
+         Field = require ("App.Field.MaxwellField").MaxwellField,
+         CollisionlessEmSource = require "App.FluidSources.CollisionlessEmSource",
+         TenMomentRelaxSource  = require "App.FluidSources.TenMomentRelaxSource",
+         AxisymmetricMomentSource = require "App.FluidSources.AxisymmetricMomentSource",
+         AxisymmetricPhMaxwellSource = require "App.FluidSources.AxisymmetricPhMaxwellSource",
+         BraginskiiHeatConductionSource = require "App.FluidSources.BraginskiiHeatConductionSource",
+         BraginskiiViscosityDiffusionSource = require "App.FluidSources.BraginskiiViscosityDiffusionSource",
       }
    end
 }

--- a/App/Projection/MomentProjection.lua
+++ b/App/Projection/MomentProjection.lua
@@ -1,0 +1,84 @@
+-- Gkyl ------------------------------------------------------------------------
+--
+-- App support code: MomentProjection object.
+--
+--    _______     ___
+-- + 6 @ |||| # P ||| +
+--------------------------------------------------------------------------------
+
+local ProjectionBase   = require "App.Projection.ProjectionBase"
+local Proto            = require "Lib.Proto"
+local Updater          = require "Updater"
+local xsys             = require "xsys"
+local AdiosCartFieldIo = require "Io.AdiosCartFieldIo"
+
+-- Shell class for FV multimoment model projections.
+local MomentProjection = Proto(ProjectionBase)
+
+-- This ctor simply stores what is passed to it and defers actual
+-- construction to the fullInit() method below.
+function MomentProjection:init(tbl)
+   self.tbl = tbl
+end
+
+function MomentProjection:fullInit(species)
+   self.species = species
+
+   self.basis    = species.basis
+   self.confGrid = species.grid
+
+   self.cdim = self.confGrid:ndim()
+end
+
+----------------------------------------------------------------------
+-- Base class for projection of arbitrary function. No re-scaling.
+local FunctionProjection = Proto(MomentProjection)
+
+function FunctionProjection:fullInit(species)
+   FunctionProjection.super.fullInit(self, species)
+
+   local func = self.tbl.func
+   if not func then
+      func = self.tbl[1]
+   end
+   assert(func, "FunctionProjection: Must specify the function")
+   assert(type(func) == "function",
+	  "The input must be a table containing function")
+   self.project = Updater.ProjectOnBasis {
+      onGrid   = self.confGrid,
+      basis    = self.basis,
+      evaluate = func,
+      onGhosts = true
+   }
+   self.initFunc = func
+end
+
+function FunctionProjection:advance(time, inFlds, outFlds)
+   local distf = outFlds[1]
+   self.project:advance(time, {}, {distf})
+end
+----------------------------------------------------------------------
+-- Base class for reading an initial condition.
+local ReadInput = Proto(MomentProjection)
+
+function ReadInput:fullInit(species)
+   ReadInput.super.fullInit(self, species)
+
+   self.userInputFile = self.tbl.inputFile
+end
+function ReadInput:run(t, distf)
+   self.momIoRead = AdiosCartFieldIo {
+      elemType = distf:elemType(),
+      method   = "MPI",
+      metaData = {polyOrder = self.basis:polyOrder(),
+                  basisType = self.basis:id()},
+   }
+
+   local readSkin = false
+   local tm, fr     = self.momIoRead:read(distf, string.format("%s",self.userInputFile), readSkin)
+end
+----------------------------------------------------------------------
+return {
+   FunctionProjection = FunctionProjection,
+   ReadInput          = ReadInput,
+}

--- a/App/Projection/init.lua
+++ b/App/Projection/init.lua
@@ -8,6 +8,7 @@
 local FluidProjection   = require "App.Projection.FluidProjection"
 local GkProjection      = require "App.Projection.GkProjection"
 local KineticProjection = require "App.Projection.KineticProjection"
+local MomentProjection  = require "App.Projection.MomentProjection"
 local ProjectionBase    = require "App.Projection.ProjectionBase"
 local VlasovProjection  = require "App.Projection.VlasovProjection"
 
@@ -15,6 +16,7 @@ return {
    FluidProjection   = FluidProjection,
    GkProjection      = GkProjection,
    KineticProjection = KineticProjection,
+   MomentProjection  = MomentProjection,
    ProjectionBase    = ProjectionBase,
    VlasovProjection  = VlasovProjection,
 }

--- a/App/Species/MomentSpecies.lua
+++ b/App/Species/MomentSpecies.lua
@@ -6,12 +6,17 @@
 -- + 6 @ |||| # P ||| +
 --------------------------------------------------------------------------------
 
+local Grid = require "Grid"
 local DataStruct = require "DataStruct"
+local AdiosCartFieldIo = require "Io.AdiosCartFieldIo"
 local Lin = require "Lib.Linalg"
 local LinearTrigger = require "Lib.LinearTrigger"
 local Mpi = require "Comm.Mpi"
+local DecompRegionCalc = require "Lib.CartDecomp"
 local Proto = require "Lib.Proto"
-local FluidSpecies = require "App.Species.FluidSpecies"
+local Projection = require "App.Projection"
+local ProjectionBase = require "App.Projection.ProjectionBase"
+local SpeciesBase = require "App.Species.SpeciesBase"
 local Time = require "Lib.Time"
 local Updater = require "Updater"
 local xsys = require "xsys"
@@ -20,7 +25,7 @@ local Euler = require "Eq.Euler"
 local TenMoment = require "Eq.TenMoment"
 
 -- Species object treated as moment equations.
-local MomentSpecies = Proto(FluidSpecies)
+local MomentSpecies = Proto(SpeciesBase)
 
 -- Add constants to object indicate various supported boundary conditions.
 local SP_BC_OPEN = 1
@@ -31,37 +36,289 @@ local SP_BC_WALL = 4
 -- local SP_BC_NEUMANN = 6    -- Specify the derivative (currently only for diffusion term).
 local SP_BC_AXIS = 7
 
-MomentSpecies.bcOpen = SP_BC_OPEN    -- Open BCs.
-MomentSpecies.bcCopy = SP_BC_COPY    -- Copy BCs.
-MomentSpecies.bcWall = SP_BC_WALL    -- Wall BCs.
-MomentSpecies.bcAxis = SP_BC_AXIS -- Axis BCs
+MomentSpecies.bcOpen = SP_BC_OPEN   -- Open BCs.
+MomentSpecies.bcCopy = SP_BC_COPY   -- Copy BCs.
+MomentSpecies.bcWall = SP_BC_WALL   -- Wall BCs.
+MomentSpecies.bcAxis = SP_BC_AXIS   -- Axis BCs
+
+-- This ctor simply stores what is passed to it and defers actual
+-- construction to the fullInit() method below.
+function MomentSpecies:init(tbl)
+   self.tbl = tbl
+end
 
 -- Actual function for initialization. This indirection is needed as
 -- we need the app top-level table for proper initialization.
 function MomentSpecies:fullInit(appTbl)
-   MomentSpecies.super.fullInit(self, appTbl)
+   local tbl = self.tbl -- Previously store table.
 
-   self.equation = self.tbl.equation -- Equation system to evolve.
-   self.nMoments = self.tbl.equation:numEquations()
+   self.cfl =  0.1
+   self.charge = tbl.charge and tbl.charge or 1.0
+   self.mass = tbl.mass and tbl.mass or 1.0
+   self.ioMethod = "MPI"
+
+   self.evolve = xsys.pickBool(tbl.evolve, true) -- Default: evolve species.
+   self.forceWrite = xsys.pickBool(tbl.forceWrite, false) -- Default: don't write species if not evolved.
+
+   -- Create triggers to write diagnostics.
+   if tbl.nDiagnosticFrame then
+      self.diagIoTrigger = LinearTrigger(0, appTbl.tEnd, tbl.nDiagnosticFrame)
+   else
+      self.diagIoTrigger = LinearTrigger(0, appTbl.tEnd, appTbl.nFrame)
+   end
+
+   self.diagIoFrame = 0 -- Frame number for diagnostics.
+   self.dynVecRestartFrame = 0 -- Frame number of restarts (for DynVectors only)
+
+   -- For storing integrated moments.
+   self.integratedMoments = nil -- Allocated in alloc() method.
+
+   -- Store initial condition function.
+   self.initFunc = tbl.init
+
+   self.equation = tbl.equation -- Equation system to evolve.
+   self.nMoments = tbl.equation:numEquations()
    self.nGhost = 2     -- We need two ghost-cells.
 
-   self.limiter = self.tbl.limiter and self.tbl.limiter or "monotonized-centered"
+   self.hasNonPeriodicBc = false -- To indicate if we have non-periodic BCs.
+   self.bcx, self.bcy, self.bcz = { }, { }, { }
+
+   -- Read in boundary conditions.
+   -- Check to see if bc type is good is now done in createBc.
+   if tbl.bcx then
+      self.bcx[1], self.bcx[2] = tbl.bcx[1], tbl.bcx[2]
+      self.hasNonPeriodicBc = true
+   end
+   if tbl.bcy then
+      self.bcy[1], self.bcy[2] = tbl.bcy[1], tbl.bcy[2]
+      self.hasNonPeriodicBc = true
+   end
+   if tbl.bcz then
+      self.bcz[1], self.bcz[2] = tbl.bcz[1], tbl.bcz[2]
+      self.hasNonPeriodicBc = true
+   end
+
+   self.ssBc = {}
+   if tbl.ssBc then
+      self.ssBc[1] = tbl.ssBc[1]
+   end
+
+   self.boundaryConditions = { } -- List of Bcs to apply.
+   self.ssBoundaryConditions = { } -- List of stair-stepped Bcs to apply.
+
+   self.bcTime = 0.0 -- Timer for BCs.
+
+   -- Initialization.
+   self.projections = {}
+   for nm, val in pairs(tbl) do
+      if ProjectionBase.is(val) then
+         self.projections[nm] = val
+      end
+   end
+   -- It is possible to use the keyword 'source' to specify a
+   -- function directly without using a Projection object.
+   if type(tbl.init) == "function" then
+      self.projections["init"] = Projection.MomentProjection.FunctionProjection {
+         func = function (t, zn)
+            return tbl.init(t, zn, self)
+         end,
+      }
+   elseif type(tbl.init) == "string" then
+      -- Specify the suffix of the file with the initial condition (including the extension).
+      -- The prefix is assumed to be the name of the input file.
+      self.projections["init"] = Projection.MomentProjection.ReadInput {
+         inputFile = tbl.init,
+      }
+   end
+   if type(tbl.source) == "function" then
+      self.projections["source"] = Projection.MomentProjection.FunctionProjection {
+         func = function (t, zn)
+            return tbl.source(t, zn, self)
+         end,
+      }
+   elseif type(tbl.source) == "string" then
+      -- Specify the suffix of the file with the source (including the extension).
+      -- The prefix is assumed to be the name of the input file.
+      self.projections["source"] = Projection.MomentProjection.ReadInput {
+         inputFile = tbl.source,
+      }
+   end
+
+   self.useShared = xsys.pickBool(appTbl.useShared, false)
+
+   self.tCurr = 0.0
+
+   self.limiter = tbl.limiter and tbl.limiter or "monotonized-centered"
    self.hyperSlvr = {} -- List of solvers.
 
    -- Invariant (positivity-preserving) equation system to evolve.
-   self.equationInv = self.tbl.equationInv
+   self.equationInv = tbl.equationInv
    self.hyperSlvrInv = {} -- List of solvers.
-   self.limiterInv = self.tbl.limiterInv and self.tbl.limiterInv or "zero"
+   self.limiterInv = tbl.limiterInv and tbl.limiterInv or "zero"
    -- Always use invariant eqn.
-   self.forceInv = self.tbl.forceInv and (self.equationInv ~= nil)
+   self.forceInv = tbl.forceInv and (self.equationInv ~= nil)
    -- Use invariant eqn. in next step; could change during run.
    self.tryInv = false
 
    self._myIsInv = ffi.new("int[2]")
    self._isInv = ffi.new("int[2]")
 
-   self._hasSsBnd = xsys.pickBool(self.tbl.hasSsBnd, false)
-   self._inOutFunc = self.tbl.inOutFunc
+   self._hasSsBnd = xsys.pickBool(tbl.hasSsBnd, false)
+   self._inOutFunc = tbl.inOutFunc
+
+   self.basis = nil -- Will be set later
+end
+
+function MomentSpecies:getCharge() return self.charge end
+function MomentSpecies:getMass() return self.mass end
+function MomentSpecies:getEvolve() return self.evolve end
+
+function MomentSpecies:setName(nm)
+   self.name = nm
+end
+function MomentSpecies:setCfl(cfl)
+   self.cfl = cfl
+end
+function MomentSpecies:setIoMethod(ioMethod)
+   self.ioMethod = ioMethod
+end
+function MomentSpecies:setConfBasis(basis)
+   self.basis = basis
+end
+function MomentSpecies:setConfGrid(cgrid)
+   self.grid = cgrid
+   self.ndim = self.grid:ndim()
+end
+
+function MomentSpecies:createGrid(cgrid)
+   self.cdim = cgrid:ndim()
+   self.ndim = self.cdim
+
+   -- Create decomposition.
+   local decompCuts = {}
+   for d = 1, self.cdim do table.insert(decompCuts, cgrid:cuts(d)) end
+   self.decomp = DecompRegionCalc.CartProd {
+      cuts = decompCuts,
+      useShared = self.useShared,
+   }
+
+   -- Create computational domain.
+   local lower, upper, cells = {}, {}, {}
+   for d = 1, self.cdim do
+      table.insert(lower, cgrid:lower(d))
+      table.insert(upper, cgrid:upper(d))
+      table.insert(cells, cgrid:numCells(d))
+   end
+   self.grid = Grid.RectCart {
+      lower = lower,
+      upper = upper,
+      cells = cells,
+      periodicDirs = cgrid:getPeriodicDirs(),
+      decomposition = self.decomp,
+   }
+end
+
+function MomentSpecies:allocMoment()
+   local m = DataStruct.Field {
+      onGrid = self.grid,
+      numComponents = self.basis:numBasis(),
+      ghost = {self.nGhost, self.nGhost}
+   }
+   return m
+end
+function MomentSpecies:allocVectorMoment(numComp)
+   local m = DataStruct.Field {
+      onGrid = self.grid,
+      numComponents = self.basis:numBasis()*numComp,
+      ghost = {self.nGhost, self.nGhost}
+   }
+   return m
+end
+
+function MomentSpecies:allocMomCouplingFields()
+   return {self:allocVectorMoment(self.nMoments)}
+end
+
+function MomentSpecies:bcCopyFunc(dir, tm, idxIn, fIn, fOut)
+   for i = 1, self.nMoments*self.basis:numBasis() do
+      fOut[i] = fIn[i]
+   end
+end
+
+-- Function to construct a BC updater.
+function MomentSpecies:makeBcUpdater(dir, edge, bcList, skinLoop, hasExtFld)
+
+   return Updater.Bc {
+      onGrid = self.grid,
+      boundaryConditions = bcList,
+      dir = dir,
+      edge = edge,
+      skinLoop = skinLoop,
+      cdim = self.cdim,
+      vdim = self.vdim,
+      hasExtFld = hasExtFld,
+   }
+end
+
+-- Function to construct a stair-stepped BC updater.
+function MomentSpecies:makeSsBcUpdater(dir, inOut, bcList)
+   return Updater.StairSteppedBc {
+      onGrid = self.grid,
+      inOut = inOut,
+      boundaryConditions = bcList,
+      dir = dir,
+   }
+end
+
+function MomentSpecies:createBCs()
+   -- Create a table to store auxiliary values needed by BCs
+   -- and provided by the user in the input file.
+   self.auxBCvalues = {}
+
+   -- Functions to make life easier while reading in BCs to apply.
+   -- Note: appendBoundaryConditions defined in sub-classes.
+   local function handleBc(dir, bc, isPeriodic)
+      table.insert(self.auxBCvalues,{nil,nil})
+
+      local dirNames = {"X", "Y", "Z"}
+      if (isPeriodic) then
+         assert(bc==nil or (bc[1]==nil and bc[2]==nil),
+                "Boundary conditions supplied in periodic direction "..
+                dirNames[dir]..".")
+      end
+
+      if bc[1] then
+         self:appendBoundaryConditions(dir, 'lower', bc[1])
+         if type(bc[1]) == "table" then
+            self.auxBCvalues[dir][1] = bc[1][2]
+         end
+      else
+         assert(isPeriodic,
+                "Invalid lower boundary condition in non-periodic direction "..
+                dirNames[dir]..".")
+      end
+
+      if bc[2] then
+         self:appendBoundaryConditions(dir, 'upper', bc[2])
+         if type(bc[2]) == "table" then
+            self.auxBCvalues[dir][2] = bc[2][2]
+         end
+      else
+         assert(isPeriodic,
+                "Invalid upper boundary condition in non-periodic direction "..
+                dirNames[dir]..".")
+      end
+   end
+
+   -- Add various BCs to list of BCs to apply.
+   local isPeriodic = {false, false, false}
+   for _,dir in ipairs(self.grid:getPeriodicDirs()) do
+      isPeriodic[dir] = true
+   end
+   local bc = {self.bcx, self.bcy, self.bcz}
+   for d = 1, self.cdim do
+     handleBc(d, bc[d], isPeriodic[d])
+  end
 end
 
 function MomentSpecies:createSolver(hasE, hasB)
@@ -123,11 +380,78 @@ function MomentSpecies:createSolver(hasE, hasB)
 
 end
 
-function MomentSpecies:advance(tCurr, species, emIn, inIdx, outIdx)
-   -- Does nothing: perhaps when DG is supported this will need to be
-   -- modified.
+function MomentSpecies:alloc(nRkDup)
+   -- Allocate fields needed in RK update.
+   self.moments = {}
+   for i = 1, nRkDup do
+      self.moments[i] = self:allocVectorMoment(self.nMoments)
+      self.moments[i]:clear(0.0)
+   end
+   -- Create Adios object for field I/O.
+   self.momIo = AdiosCartFieldIo {
+      elemType = self.moments[1]:elemType(),
+      method = self.ioMethod,
+      metaData = {
+         polyOrder = self.basis:polyOrder(),
+         basisType = self.basis:id(),
+         charge = self.charge,
+         mass = self.mass,
+      },
+   }
+   self.couplingMoments = self:allocVectorMoment(self.nMoments)
+   self.integratedMoments = DataStruct.DynVector { numComponents = self.nMoments }
 
-   return true, GKYL_MAX_DOUBLE
+   -- Array with one component per cell to store cflRate in each cell.
+   self.cflRateByCell = DataStruct.Field {
+      onGrid = self.grid,
+      numComponents = 1,
+      ghost = {1, 1},
+   }
+   self.cflRateByCell:clear(0.0)
+   self.cflRatePtr = self.cflRateByCell:get(1)
+   self.cflRateIdxr = self.cflRateByCell:genIndexer()
+   self.dtGlobal = ffi.new("double[2]")
+
+   self:createBCs()
+end
+
+function MomentSpecies:initDist(extField)
+
+   local initCnt = 0
+   for nm, pr in pairs(self.projections) do
+      pr:fullInit(self)
+      pr:advance(0.0, {}, {self.moments[2]})
+      -- This barrier is needed as when using MPI-SHM some
+      -- processes will get to accumulate before projection is finished.
+      Mpi.Barrier(self.grid:commSet().sharedComm)
+      if nm == "init" then
+         self.moments[1]:accumulate(1.0, self.moments[2])
+         initCnt = initCnt + 1
+      end
+      if nm == "source" then
+         if not self.mSource then
+            self.mSource = self:allocVectorMoment(self.nMoments)
+         end
+         self.mSource:accumulate(1.0, self.moments[2])
+      end
+   end
+   assert(initCnt > 0,
+          string.format("MomentSpecies: Species '%s' not initialized!", self.name))
+   self.moments[2]:clear(0.0)
+
+end
+
+function MomentSpecies:rkStepperFields()
+   return self.moments
+end
+
+-- For timestepping.
+function MomentSpecies:copyRk(outIdx, aIdx)
+   self:rkStepperFields()[outIdx]:copy(self:rkStepperFields()[aIdx])
+end
+
+function MomentSpecies:setDtGlobal(dtGlobal)
+   self.dtGlobal[0] = dtGlobal
 end
 
 function MomentSpecies:appendBoundaryConditions(dir, edge, bcType)
@@ -218,12 +542,112 @@ function MomentSpecies:updateInDirection(dir, tCurr, dt, fIn, fOut, tryInv)
    return status, dtSuggested, tryInv_next
 end
 
+function MomentSpecies:applyBcIdx(tCurr, idx, isFirstRk)
+  for dir = 1, self.ndim do
+     self:applyBc(tCurr, self:rkStepperFields()[idx], dir)
+  end
+end
+
+function MomentSpecies:applyBc(tCurr, fIn, dir)
+   local tmStart = Time.clock()
+   if self.evolve then
+      if self.hasNonPeriodicBc then
+         for _, bc in ipairs(self.boundaryConditions) do
+            if (not dir) or dir == bc:getDir() then
+               bc:advance(tCurr, {}, {fIn})
+            end
+         end
+      end
+      for _, bc in ipairs(self.ssBoundaryConditions) do
+         if (not dir) or dir == bc:getDir() then
+             bc:advance(tCurr, {}, {fIn})
+          end
+       end
+      fIn:sync()
+   end
+   self.bcTime = self.bcTime + Time.clock()-tmStart
+end
+
+function MomentSpecies:createDiagnostics()
+   -- Create updater to compute volume-integrated moments.
+   self.intMom2Calc = Updater.CartFieldIntegratedQuantCalc {
+      onGrid = self.grid,
+      basis = self.basis,
+      numComponents = self.nMoments,
+      quantity = "V"
+   }
+end
+
+function MomentSpecies:write(tm, force)
+   if self.evolve or self.forceWrite then
+      -- Compute integrated diagnostics.
+      self.intMom2Calc:advance(tm, { self.moments[1] }, { self.integratedMoments })
+
+      -- Only write stuff if triggered.
+      if self.diagIoTrigger(tm) or force then
+         self.momIo:write(
+            self.moments[1], string.format("%s_%d.bp", self.name, self.diagIoFrame), tm, self.diagIoFrame)
+         self.integratedMoments:write(
+            string.format("%s_intMom.bp", self.name), tm, self.diagIoFrame)
+
+         if tm == 0.0 and self.mSource then
+            self.momIo:write(self.mSource, string.format("%s_mSource_0.bp", self.name), tm, self.diagIoFrame)
+         end
+
+         self.diagIoFrame = self.diagIoFrame+1
+      end
+   else
+      -- If not evolving species, don't write anything except initial conditions.
+      if self.diagIoFrame == 0 then
+         self.momIo:write(self.moments[1], string.format("%s_%d.bp", self.name, 0), tm, 0)
+      end
+      self.diagIoFrame = self.diagIoFrame+1
+   end
+end
+
+function MomentSpecies:writeRestart(tm)
+   self.momIo:write(
+      self.moments[1], string.format("%s_restart.bp", self.name), tm, self.diagIoFrame)
+
+   -- Write restart files for integrated moments. Note: these are only needed for the rare case that the
+   -- restart write frequency is higher than the normal write frequency from nFrame.
+   -- (the first "false" prevents flushing of data after write, the second "false" prevents appending)
+   self.integratedMoments:write(
+      string.format("%s_intMom_restart.bp", self.name), tm, self.dynVecRestartFrame, false, false)
+   self.dynVecRestartFrame = self.dynVecRestartFrame + 1
+end
+
+function MomentSpecies:readRestart()
+   local tm, fr = self.momIo:read(self.moments[1], string.format("%s_restart.bp", self.name))
+   self.diagIoFrame = fr -- Reset internal frame counter.
+   self.integratedMoments:read(string.format("%s_intMom_restart.bp", self.name))
+
+   for dir = 1, self.ndim do
+      self:applyBc(tm, self.moments[1], dir)
+   end
+   self.moments[1]:sync() -- Must get all ghost-cell data correct.
+
+   -- Iterate triggers.
+   self.diagIoTrigger(tm)
+
+   return tm
+end
+
 function MomentSpecies:totalSolverTime()
    local tm = 0.0
    for d = 1, self.grid:ndim() do
       tm = tm + self.hyperSlvr[d].totalTime
    end
    return tm
+end
+function MomentSpecies:totalBcTime()
+   return self.bcTime
+end
+function MomentSpecies:momCalcTime()
+   return 0
+end
+function MomentSpecies:intMomCalcTime()
+   return self.intMom2Calc.totalTime
 end
 
 function MomentSpecies:checkInv(fIn)

--- a/App/Species/SpeciesBase.lua
+++ b/App/Species/SpeciesBase.lua
@@ -37,6 +37,7 @@ function SpeciesBase:write(tm) end
 function SpeciesBase:writeRestart(tm) end
 function SpeciesBase:readRestart() return 0.0 end
 function SpeciesBase:advance(tCurr, fIn, emIn, fRhsOut)
+   return true, GKYL_MAX_DOUBLE
 end
 function SpeciesBase:updateInDirection(dir, tCurr, dt, fIn, fOut)
    return true, GKYL_MAX_DOUBLE


### PR DESCRIPTION
Currently MomentSpecies is a child of FluidSpecies. But MomentSpecies is for the FV multimoment model, and FluidSpecies is also being used for other DG models (IncompEuler, AdiabaticSpecies, and soon GyroFluidSpecies). This adds complexity and messiness where there need be none.

So best to separate MomentSpecies into its own independent species. This simplifies the multi moment model app some, and allows those working on FV multimoment to edit at will without having to worry about affecting the DG fluids.

Ran the hyper-euler, hyper-maxwell and mom regression tests and they pass (except for the mom tests requiring a parallel runs or separate files for elliptic integrals).