### PR TITLE
Fix option to read source from file

### DIFF
--- a/App/Projection/VlasovProjection.lua
+++ b/App/Projection/VlasovProjection.lua
@@ -28,10 +28,8 @@ function MaxwellianProjection:lagrangeFix(distf)
    local M2, dM2 = self.species:allocMoment(), self.species:allocMoment()
 
    local project = Updater.ProjectOnBasis {
-      onGrid   = self.confGrid,
-      basis    = self.confBasis,
-      evaluate = function(t,xn) return 0. end,
-      onGhosts = true,
+      onGrid = self.confGrid,   evaluate = function(t,xn) return 0. end,
+      basis  = self.confBasis,  onGhosts = true,
    }
 
    self.species.numDensityCalc:advance(0.0, {distf}, {M0})
@@ -73,11 +71,9 @@ function MaxwellianProjection:lagrangeFix(distf)
    dM2:accumulate(-1.0, M2)
    
    local lagFix = Updater.LagrangeFix {
-      onGrid     = self.phaseGrid,
-      phaseBasis = self.phaseBasis,
+      onGrid     = self.phaseGrid,   confBasis = self.confBasis,
+      phaseBasis = self.phaseBasis,  mode      = 'vlasov',
       confGrid   = self.confGrid,
-      confBasis  = self.confBasis,
-      mode       = 'vlasov'
    }
    lagFix:advance(0.0, {dM0, dM1, dM2}, {distf})
 end
@@ -85,12 +81,8 @@ end
 function MaxwellianProjection:advance(t, inFlds, outFlds)
    local distf = outFlds[1]
    self.project:advance(t, {}, {distf})
-   if self.exactScaleM0 then
-      self:scaleDensity(distf)
-   end
-   if self.exactLagFixM012 then
-      self:lagrangeFix(distf)
-   end
+   if self.exactScaleM0 then self:scaleDensity(distf) end
+   if self.exactLagFixM012 then self:lagrangeFix(distf) end
 end
 
 ----------------------------------------------------------------------

--- a/App/Sources/VmSource.lua
+++ b/App/Sources/VmSource.lua
@@ -40,25 +40,23 @@ function VmSource:fullInit(speciesTbl)
          self.profile = Projection.FunctionProjection{fromFile = tbl.profile,}
       end
    elseif tbl.kind then
-      self.density     = assert(tbl.density, "App.VmSource: must specify density profile of source in 'density'.")
-      self.temperature = assert(tbl.temperature, "App.VmSource: must specify temperature profile of source in 'density'.")
+      self.density     = assert(tbl.density or tbl.fromFile, "App.VmSource: If not importing source with 'fromFile' must specify density profile of source in 'density'.")
+      self.temperature = assert(tbl.temperature or tbl.fromFile, "App.VmSource: If not importing source with 'fromFile' must specify temperature profile of source in 'density'.")
       if tbl.kind == "Maxwellian" or tbl.kind == "maxwellian" then
          self.profile = Projection.MaxwellianProjection {
-            density     = self.density,
-            temperature = self.temperature,
-            power       = self.power,
+            density     = self.density,      power    = self.power,
+            temperature = self.temperature,  fromFile = tbl.fromFile,
          }
       else
          assert(false, "App.VmSource: Source kind not recognized.")
       end    
    else
       -- If user doesn't specify 'kind', default to Maxwellian.
-      self.density     = assert(tbl.density, "App.VmSource: must specify density profile of source in 'density'.")
-      self.temperature = assert(tbl.temperature, "App.VmSource: must specify temperature profile of source in 'density'.")
+      self.density     = assert(tbl.density or tbl.fromFile, "App.VmSource: If not importing source with 'fromFile' must specify density profile of source in 'density'.")
+      self.temperature = assert(tbl.temperature or tbl.fromFile, "App.VmSource: If not importing source with 'fromFile' must specify temperature profile of source in 'density'.")
       self.profile     = Projection.MaxwellianProjection {
-         density     = self.density,
-         temperature = self.temperature,
-         power       = self.power,
+         density     = self.density,      power    = self.power,
+         temperature = self.temperature,  fromFile = tbl.fromFile,
       }
    end
    self.tmEvalSrc = 0.0
@@ -86,10 +84,8 @@ function VmSource:createSolver(mySpecies, extField)
 
    if self.power then
       local calcInt = Updater.CartFieldIntegratedQuantCalc {
-         onGrid        = self.confGrid,
-         basis         = self.confBasis,
-         numComponents = 1,
-         quantity      = "V",
+         onGrid = self.confGrid,   numComponents = 1,
+         basis  = self.confBasis,  quantity      = "V",
       }
       local intKE = DataStruct.DynVector{numComponents = 1}
       mySpecies.ptclEnergyCalc:advance(0.0, {self.fSource}, {mySpecies.ptclEnergyAux})


### PR DESCRIPTION
This capability seems to have been lost when sources where moved into an App. Now one can do it two ways, through `fromFile=<file_name_suffix.bp>` or through `profile=<file_name_suffix.bp>`.

Note that there is some inconsistency in the code though. `fromFile` is meant to be used with `density` and `temperature`, so it calls MaxwellianProjection and DOES NOT scale by the phase-space Jacobian (B*). However if the file contains the raw source, without the phase-space Jacobian one should use `profile`, which then uses FunctionProjection and scales by that Jacobian. This should be made more consistent/error-prone.

Also, one has to be careful when importing sources and using `power` and `scaleWithSourcePower`. Because if you are importing a source that has already been scaled in another simulation, then it may think that the scaling factor for your ICs should just be 1, and you may start with the wrong ICs.

Reg tests that use Plasma.Source pass, except for gk-neutral tests which are doing their usual pass/fail dance, so I assume they pass.

I also tested reading the source with gk-sheath-1x2v-p1. However I learned that to get the same results I cannot use the power and scale by power options (unless you are also reading ICs from file), and the sources need to be written out with the ghost cells. This begs the question of why the sources are needed in the ghost cells at all. They shouldn't be defined/needed there.