### PR TITLE
Changes to binOp and Updater/Base

### DIFF
--- a/App/BCs/BronoldFehskeReflection.lua
+++ b/App/BCs/BronoldFehskeReflection.lua
@@ -239,16 +239,16 @@ function BnFReflectionBC:createSolver(mySpecies, field, externalField)
 
          -- Set up weak multiplication and division operators (for diagnostics).
          self.confWeakMultiply = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "Multiply",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "Multiply",
+            onGhosts  = true,
          }
          self.confWeakDivide = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "Divide",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "Divide",
+            onRange   = self.confBoundaryField:localExtRange(),  onGhosts = true,
          }
          self.confWeakDotProduct = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "DotProduct",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "DotProduct",
+            onGhosts  = true,
          }
          -- Volume integral operator (for diagnostics).
          self.volIntegral = {

--- a/App/BCs/GkBasic.lua
+++ b/App/BCs/GkBasic.lua
@@ -371,12 +371,12 @@ function GkBasicBC:createSolver(mySpecies, field, externalField)
          end
          -- Set up weak multiplication and division operators (for diagnostics).
          self.confWeakMultiply = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "Multiply",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "Multiply",
+            onGhosts  = true,
          }
          self.confWeakDivide = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "Divide",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "Divide",
+            onRange   = self.confBoundaryField:localExtRange(),  onGhosts = true,
          }
          -- Volume integral operator (for diagnostics).
          self.volIntegral = {

--- a/App/BCs/NeutralRecycling.lua
+++ b/App/BCs/NeutralRecycling.lua
@@ -194,14 +194,9 @@ function NeutralRecyclingBC:createSolver(mySpecies, field, externalField)
       phaseBasis = self.basis,         moment     = mom,
    }
 
-   self.recycleConfWeakDivide = Updater.CartFieldBinOp {
-      onGrid    = self.confBoundaryGrid,  operation = "Divide",
-      weakBasis = self.confBasis,         onGhosts  = false,
-   }
    self.recycleConfPhaseWeakMultiply = Updater.CartFieldBinOp {
-      onGrid     = self.boundaryGrid,  operation = "Multiply",
-      weakBasis  = self.basis,         onGhosts  = false,
-      fieldBasis = self.confBasis, 
+      weakBasis  = self.basis,  operation = "Multiply",
+      fieldBasis = self.confBasis,
    }
 
    local recycleSource = function (t, xn)
@@ -317,16 +312,16 @@ function NeutralRecyclingBC:createSolver(mySpecies, field, externalField)
 
          -- Set up weak multiplication and division operators (for diagnostics).
          self.confWeakMultiply = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "Multiply",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "Multiply",
+            onGhosts  = true,
          }
          self.confWeakDivide = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "Divide",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "Divide",
+            onRange   = self.confBoundaryField:localExtRange(),  onGhosts = true,
          }
          self.confWeakDotProduct = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "DotProduct",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "DotProduct",
+            onGhosts  = true,
          }
          -- Volume integral operator (for diagnostics).
          self.volIntegral = {
@@ -381,6 +376,11 @@ function NeutralRecyclingBC:createCouplingSolver(species, field, externalField)
 
    self.recIonBC = recIon.nonPeriodicBCs[string.gsub(self.name,self.speciesName.."_","")]
    self.bcIonM0fluxField = self.recIonBC:allocMoment() 
+
+   self.recycleConfWeakDivide = Updater.CartFieldBinOp {
+      weakBasis = self.confBasis,  operation = "Divide",
+      onRange   = self.bcIonM0fluxField:localRange(),
+   }
 end
 
 function NeutralRecyclingBC:storeBoundaryFlux(tCurr, rkIdx, qOut)

--- a/App/BCs/TwistShift.lua
+++ b/App/BCs/TwistShift.lua
@@ -203,12 +203,12 @@ function TwistShiftBC:createSolver(mySpecies, field, externalField)
          end
          -- Set up weak multiplication and division operators (for diagnostics).
          self.confWeakMultiply = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "Multiply",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "Multiply",
+            onGhosts  = true,
          }
          self.confWeakDivide = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "Divide",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "Divide",
+            onRange   = self.confBoundaryField:localExtRange(),  onGhosts = true,
          }
          -- Volume integral operator (for diagnostics).
          self.volIntegral = {

--- a/App/BCs/VlasovBasic.lua
+++ b/App/BCs/VlasovBasic.lua
@@ -219,16 +219,16 @@ function VlasovBasicBC:createSolver(mySpecies, field, externalField)
          end
          -- Set up weak multiplication and division operators (for diagnostics).
          self.confWeakMultiply = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "Multiply",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "Multiply",
+            onGhosts  = true,
          }
          self.confWeakDivide = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "Divide",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "Divide",
+            onRange   = self.confBoundaryField:localExtRange(),  onGhosts = true,
          }
          self.confWeakDotProduct = Updater.CartFieldBinOp {
-            onGrid    = self.confBoundaryGrid,  operation = "DotProduct",
-            weakBasis = self.confBasis,         onGhosts  = true,
+            weakBasis = self.confBasis,  operation = "DotProduct",
+            onGhosts  = true,
          }
          -- Volume integral operator (for diagnostics).
          self.volIntegral = {

--- a/App/Collisions/GkBGKCollisions.lua
+++ b/App/Collisions/GkBGKCollisions.lua
@@ -331,10 +331,8 @@ function GkBGKCollisions:createSolver(mySpecies, externalField)
       end
       -- Weak multiplication to multiply nu(x) with fMaxwell.
       self.phaseMul = Updater.CartFieldBinOp {
-         onGrid     = self.phaseGrid,
-         weakBasis  = self.phaseBasis,
+         weakBasis  = self.phaseBasis,  operation = "Multiply",
          fieldBasis = self.confBasis,
-         operation  = "Multiply",
       }
    else
       self.nuSum = 0.0  -- Assigned in advance method.
@@ -366,14 +364,10 @@ function GkBGKCollisions:createSolver(mySpecies, externalField)
          self.crossMaxwellianM1 = self:createConfField()
          self.crossMaxwellianM2 = self:createConfField()
          self.confMultiply = Updater.CartFieldBinOp {
-            onGrid    = self.confGrid,
-            weakBasis = self.confBasis,
-            operation = "Multiply",
+            weakBasis = self.confBasis,  operation = "Multiply",
          }
          self.confDotProduct = Updater.CartFieldBinOp {
-            onGrid    = self.confGrid,
-            weakBasis = self.confBasis,
-            operation = "DotProduct",
+            weakBasis = self.confBasis,  operation = "DotProduct",
          }
       end
    end

--- a/App/Collisions/GkLBOCollisions.lua
+++ b/App/Collisions/GkLBOCollisions.lua
@@ -271,9 +271,7 @@ function GkLBOCollisions:createSolver(mySpecies, externalField)
       end
       -- Weak multiplication to multiply nu(x) with uPar or vtSq.
       self.confMul = Updater.CartFieldBinOp {
-         onGrid    = self.confGrid,
-         weakBasis = self.confBasis,
-         operation = "Multiply",
+         weakBasis = self.confBasis,  operation = "Multiply",
       }
    else
       self.nuSum = 0.0    -- Assigned in advance method.

--- a/App/Collisions/VmBGKCollisions.lua
+++ b/App/Collisions/VmBGKCollisions.lua
@@ -278,10 +278,8 @@ function VmBGKCollisions:createSolver(mySpecies, externalField)
       end
       -- Weak multiplication to multiply nu(x) with fMaxwell.
       self.phaseMul = Updater.CartFieldBinOp {
-         onGrid     = self.phaseGrid,
-         weakBasis  = self.phaseBasis,
+         weakBasis  = self.phaseBasis,  operation = "Multiply",
          fieldBasis = self.confBasis,
-         operation  = "Multiply",
       }
    else
       self.nuSum = 0.0  -- Assigned in advance method.
@@ -317,14 +315,10 @@ function VmBGKCollisions:createSolver(mySpecies, externalField)
          self.crossMaxwellianM1 = createConfFieldCompV()
          self.crossMaxwellianM2 = createConfFieldComp1()
          self.confMultiply = Updater.CartFieldBinOp {
-            onGrid    = self.confGrid,
-            weakBasis = self.confBasis,
-            operation = "Multiply",
+            weakBasis = self.confBasis,  operation = "Multiply",
          }
          self.confDotProduct = Updater.CartFieldBinOp {
-            onGrid    = self.confGrid,
-            weakBasis = self.confBasis,
-            operation = "DotProduct",
+            weakBasis = self.confBasis,  operation = "DotProduct",
          }
       end
    end

--- a/App/Collisions/VmLBOCollisions.lua
+++ b/App/Collisions/VmLBOCollisions.lua
@@ -298,9 +298,7 @@ function VmLBOCollisions:createSolver(mySpecies, extField)
       end
       -- Weak multiplication to multiply nu(x) with u or vtSq.
       self.confMul = Updater.CartFieldBinOp {
-         onGrid    = self.confGrid,
-         weakBasis = self.confBasis,
-         operation = "Multiply",
+         weakBasis = self.confBasis,  operation = "Multiply",
       }
    else
       self.nuSum    = 0.0    -- Assigned in advance method.

--- a/App/Field/GkField.lua
+++ b/App/Field/GkField.lua
@@ -393,12 +393,12 @@ function GkField:createSolver(species, externalField)
    end
 
    self.weakMultiply = Updater.CartFieldBinOp {
-      onGrid    = self.grid,   operation = "Multiply",
-      weakBasis = self.basis,  onGhosts  = true,
+      weakBasis = self.basis,  operation = "Multiply",
+      onGhosts  = true,
    }
    self.weakDivide = Updater.CartFieldBinOp {
-      onGrid    = self.grid,   operation = "Divide",
-      weakBasis = self.basis,  onGhosts  = false,
+      weakBasis = self.basis,  operation = "Divide",
+      onRange   = self.chargeDens:localRange(),  onGhosts = false,
    }
 
    -- When using a linearizedPolarization term in Poisson equation,
@@ -1102,12 +1102,12 @@ function GkGeometry:initField()
    -- Compute 1/B and 1/(B^2). LBO collisions require that this is
    -- done via weak operations instead of projecting 1/B or 1/B^2.
    local confWeakMultiply = Updater.CartFieldBinOp {
-      onGrid    = self.grid,   operation = "Multiply",
-      weakBasis = self.basis,  onGhosts  = true,
+      weakBasis = self.basis,  operation = "Multiply",
+      onGhosts  = true,
    }
    local confWeakDivide = Updater.CartFieldBinOp {
-      onGrid    = self.grid,   operation = "Divide",
-      weakBasis = self.basis,  onGhosts  = true,
+      weakBasis = self.basis,  operation = "Divide",
+      onRange   = self.unitWeight:localExtRange(),  onGhosts = true,
    }
    confWeakDivide:advance(0., {self.geo.bmag, self.unitWeight}, {self.geo.bmagInv})
    confWeakMultiply:advance(0., {self.geo.bmagInv, self.geo.bmagInv}, {self.geo.bmagInvSq})

--- a/App/Projection/FluidProjection.lua
+++ b/App/Projection/FluidProjection.lua
@@ -34,8 +34,8 @@ function FluidProjection:fullInit(species)
    self.fromFile = self.tbl.fromFile
 
    self.weakMultiply = Updater.CartFieldBinOp {
-      onGrid     = self.grid,   operation = "Multiply",
-      weakBasis  = self.basis,  onGhosts  = true,
+      weakBasis = self.basis,  operation = "Multiply",
+      onGhosts  = true,
    }
 end
 

--- a/App/Projection/GkProjection.lua
+++ b/App/Projection/GkProjection.lua
@@ -180,17 +180,16 @@ function MaxwellianProjection:scaleM012(distf)
 
    -- Initialize weak multiplication/division operators.
    local weakDivision = Updater.CartFieldBinOp {
-      onGrid    = self.confGrid,   operation = "Divide",
-      weakBasis = self.confBasis,  onGhosts  = true,
+      weakBasis = self.confBasis,  operation = "Divide",
+      onRange   = M0_e:localExtRange(),  onGhosts  = true,
    }
    local weakMultiplicationConf = Updater.CartFieldBinOp {
-      onGrid    = self.confGrid,   operation = "Multiply",
-      weakBasis = self.confBasis,  onGhosts  = true,
+      weakBasis = self.confBasis,  operation = "Multiply",
+      onGhosts  = true,
    }
    local weakMultiplicationPhase = Updater.CartFieldBinOp {
-      onGrid     = self.phaseGrid,   operation  = "Multiply",
-      weakBasis  = self.phaseBasis,  onGhosts   = true,
-      fieldBasis = self.confBasis,
+      weakBasis  = self.phaseBasis,  operation  = "Multiply",
+      fieldBasis = self.confBasis,   onGhosts   = true,
    }
 
    -- Calculate M0_mod = M0_e / M0.
@@ -249,10 +248,8 @@ end
 --      return vpar*self.initFunc(t,zn)
 --   end
 --   local project_vpar = Updater.ProjectOnBasis {
---      onGrid   = self.phaseGrid,
---      basis    = self.phaseBasis,
---      evaluate = distf_vparFunc,
---      onGhosts = true
+--      onGrid = self.phaseGrid,   evaluate = distf_vparFunc,
+--      basis  = self.phaseBasis,  onGhosts = true
 --   }
 --   project_vpar:advance(0.0, {}, {distf_vpar})
 --   local distf_vpar2Func = function (t, zn)
@@ -260,10 +257,8 @@ end
 --      return vpar^2*self.initFunc(t,zn)
 --   end
 --   local project_vpar2 = Updater.ProjectOnBasis {
---      onGrid   = self.phaseGrid,
---      basis    = self.phaseBasis,
---      evaluate = distf_vpar2Func,
---      onGhosts = true
+--      onGrid = self.phaseGrid,   evaluate = distf_vpar2Func,
+--      basis  = self.phaseBasis,  onGhosts = true
 --   }
 --   project_vpar2:advance(0.0, {}, {distf_vpar2})
 --   if self.vdim == 2 then 
@@ -272,37 +267,29 @@ end
 --         return mu*sp.bmagFunc(t,zn)*self.initFunc(t,zn)
 --      end
 --      local project_muB = Updater.ProjectOnBasis {
---         onGrid   = self.phaseGrid,
---         basis    = self.phaseBasis,
---         evaluate = distf_muBFunc,
---         onGhosts = true
+--         onGrid = self.phaseGrid,   evaluate = distf_muBFunc,
+--         basis  = self.phaseBasis,  onGhosts = true
 --      }
 --      project_muB:advance(0.0, {}, {distf_muB})
 --   end
 --
---   -- initialize weak multiplication/division operators
---   local weakDivision = Updater.CartFieldBinOp {
---      onGrid = self.confGrid,
---      weakBasis = self.confBasis,
---      operation = "Divide",
---      onGhosts = true,
---   }
---   local weakMultiplicationConf = Updater.CartFieldBinOp {
---      onGrid = self.confGrid,
---      weakBasis = self.confBasis,
---      operation = "Multiply",
---      onGhosts = true,
---   }
---   local weakMultiplicationPhase = Updater.CartFieldBinOp {
---      onGrid = self.phaseGrid,
---      weakBasis = self.phaseBasis,
---      fieldBasis = self.confBasis,
---      operation = "Multiply",
---      onGhosts = true,
---   }
---
 --   -- calculate (inexact) moments of initial distribution function
 --   local Dens, M1, M2par, M2perp = sp:allocMoment(), sp:allocMoment(), sp:allocMoment(), sp:allocMoment()
+--
+--   -- initialize weak multiplication/division operators
+--   local weakDivision = Updater.CartFieldBinOp {
+--      weakBasis = self.confBasis,  operation = "Divide",
+--      onRange   = M1:localExtRange(),  onGhosts = true,
+--   }
+--   local weakMultiplicationConf = Updater.CartFieldBinOp {
+--      weakBasis = self.confBasis,  operation = "Multiply",
+--      onGhosts  = true,
+--   }
+--   local weakMultiplicationPhase = Updater.CartFieldBinOp {
+--      weakBasis  = self.phaseBasis,  operation = "Multiply",
+--      fieldBasis = self.confBasis,   onGhosts  = true,
+--   }
+--
 --   sp.numDensityCalc:advance(0.0, {distf}, {Dens})
 --   sp.momDensityCalc:advance(0.0, {distf}, {M1})
 --   sp.M2parCalc:advance(0.0, {distf}, {M2par})
@@ -327,35 +314,27 @@ end
 --   -- initialize exact moments
 --   local Dens_e, Upar_e, Temp_e = sp:allocMoment(), sp:allocMoment(), sp:allocMoment()
 --   local projectDens = Updater.ProjectOnBasis {
---      onGrid   = self.confGrid,
---      basis    = self.confBasis,
---      evaluate = function(t, zn) return self.density(t, zn, sp) end,
---      onGhosts = true,
+--      onGrid = self.confGrid,   evaluate = function(t, zn) return self.density(t, zn, sp) end,
+--      basis  = self.confBasis,  onGhosts = true,
 --   }
 --   projectDens:advance(0.0, {}, {Dens_e})
 --
 --   local projectUpar = Updater.ProjectOnBasis {
---      onGrid   = self.confGrid,
---      basis    = self.confBasis,
---      evaluate = function(t, zn) return self.driftSpeed(t, zn, sp) end,
---      onGhosts = true,
+--      onGrid = self.confGrid,   evaluate = function(t, zn) return self.driftSpeed(t, zn, sp) end,
+--      basis  = self.confBasis,  onGhosts = true,
 --   }
 --   projectUpar:advance(0.0, {}, {Upar_e})
 --
 --   local projectTemp = Updater.ProjectOnBasis {
---      onGrid   = self.confGrid,
---      basis    = self.confBasis,
---      evaluate = function(t, zn) return self.temperature(t, zn, sp) end,
---      onGhosts = true,
+--      onGrid = self.confGrid,   evaluate = function(t, zn) return self.temperature(t, zn, sp) end,
+--      basis  = self.confBasis,  onGhosts = true,
 --   }
 --   projectTemp:advance(0.0, {}, {Temp_e})
 --
 --   local unitField, TparInv, TperpInv = sp:allocMoment(), sp:allocMoment(), sp:allocMoment()
 --   local projectUnity = Updater.ProjectOnBasis {
---      onGrid   = self.confGrid,
---      basis    = self.confBasis,
---      evaluate = function(t, zn) return 1.0 end,
---      onGhosts = true,
+--      onGrid = self.confGrid,   evaluate = function(t, zn) return 1.0 end,
+--      basis  = self.confBasis,  onGhosts = true,
 --   }
 --   projectUnity:advance(0.0, {}, {unitField})
 --

--- a/App/Projection/GyrofluidProjection.lua
+++ b/App/Projection/GyrofluidProjection.lua
@@ -79,8 +79,8 @@ function GyrofluidProjection:fullInit(mySpecies)
          basis  = self.basis,  onGhosts = true,
       }
       self.weakDivide = Updater.CartFieldBinOp {
-         onGrid    = self.grid,   operation = "Divide",
-         weakBasis = self.basis,  onGhosts  = true,
+         weakBasis = self.basis,  operation = "Divide",
+         onRange   = mySpecies.moments[1]:localExtRange(),  onGhosts = true,
       }
       -- Will also need some temporary fields. Can use those declared in GyrofluidSpecies.
       self.jacM0      = mySpecies.jacM0

--- a/App/Projection/KineticProjection.lua
+++ b/App/Projection/KineticProjection.lua
@@ -45,9 +45,8 @@ function KineticProjection:fullInit(species)
    self.scaleWithSourcePower = xsys.pickBool(self.tbl.scaleWithSourcePower, false)
 
    self.weakMultiplyConfPhase = Updater.CartFieldBinOp {
-      onGrid     = self.phaseGrid,   operation = "Multiply",
-      weakBasis  = self.phaseBasis,  onGhosts  = true,
-      fieldBasis = self.confBasis,
+      weakBasis  = self.phaseBasis,  operation = "Multiply",
+      fieldBasis = self.confBasis,   onGhosts  = true,
    }
 end
 
@@ -162,8 +161,8 @@ function MaxwellianProjection:scaleDensity(distf)
    project:advance(0.0, {}, {M0e})
 
    local weakDivision = Updater.CartFieldBinOp {
-      onGrid    = self.confGrid,   operation = "Divide",
-      weakBasis = self.confBasis,  onGhosts  = true,
+      weakBasis = self.confBasis,  operation = "Divide",
+      onRange   = M0e:localExtRange(),  onGhosts  = true,
    }
 
    -- Calculate M0mod = M0e / M0.

--- a/App/Species/AdiabaticSpecies.lua
+++ b/App/Species/AdiabaticSpecies.lua
@@ -92,12 +92,11 @@ function AdiabaticSpecies:createSolver(field, externalField)
 
       -- Scale by the Jacobian.
       if externalField.geo then
-         local weakMultiply = Updater.CartFieldBinOp {
-            onGrid    = self.grid,   operation = "Multiply",
-            weakBasis = self.basis,  onGhosts  = true,
-         }
-
          local jacob = externalField.geo.jacobGeo
+         local weakMultiply = Updater.CartFieldBinOp {
+            weakBasis = self.basis,  operation = "Multiply",
+            onGhosts  = true, 
+         }
          if jacob then weakMultiply:advance(0, {self.QneutFac, jacob}, {self.QneutFac}) end
       end
    

--- a/App/Species/FluidSpecies.lua
+++ b/App/Species/FluidSpecies.lua
@@ -289,12 +289,12 @@ function FluidSpecies:createSolver(field, externalField)
    -- Operators needed for time-dependent calculation and diagnostics.
    if self.ndim <= 3 then
       self.weakMultiply = Updater.CartFieldBinOp {
-         onGrid    = self.grid,   operation = "Multiply",
-         weakBasis = self.basis,  onGhosts  = true,
+         operation = "Multiply",  weakBasis = self.basis,
+         onGhosts  = true,
       }
       self.weakDivide = Updater.CartFieldBinOp {
-         onGrid    = self.grid,   operation = "Divide",
-         weakBasis = self.basis,  onGhosts  = true,
+         operation = "Divide",  weakBasis = self.basis,
+         onRange   = self.jacob:localExtRange(),  onGhosts = true,
       }
    end
    self.volIntegral = {
@@ -364,9 +364,11 @@ function FluidSpecies:createSolver(field, externalField)
          momIn:accumulate(1.0, self.momBackground)
          momIn:sync(syncFullFperiodicDirs)
       end or function(momIn, syncFullFperiodicDirs) end 
+   print("here ",self.perturbedDiagnostics)
    self.calcDeltaMom = self.perturbedDiagnostics 
       and function(momIn) self.flucMom:combine(1.0, momIn, -1.0, self.momBackground) end
       or function(momIn) end
+   print("here 2 ",self.calcDeltaMom)
 
    if self.fluctuationBCs or self.perturbedDiagnostics then
       self.writeFluctuation = self.perturbedDiagnostics 

--- a/App/Species/GkSpecies.lua
+++ b/App/Species/GkSpecies.lua
@@ -318,17 +318,6 @@ function GkSpecies:createSolver(field, externalField)
          mass       = self.mass,
          vbounds    = vbounds,
       }
-      -- Updaters for the primitive moments.
-      self.confDiv = Updater.CartFieldBinOp {
-         onGrid    = self.confGrid,
-         weakBasis = self.confBasis,
-         operation = "Divide",
-      }
-      self.confMul = Updater.CartFieldBinOp {
-         onGrid    = self.confGrid,
-         weakBasis = self.confBasis,
-         operation = "Multiply",
-      }
    end
 
    -- Create an updater for volume integrals. Used by diagnostics.
@@ -872,25 +861,6 @@ function GkSpecies:calcCouplingMoments(tCurr, rkIdx, species)
 	 self.threeMomentsCalc:advance(tCurr, {fIn}, {self.threeMoments})
 
 	 self.primMomSelf:advance(tCurr, {self.threeMoments, fIn, self.threeMomentsBoundaryCorrections}, {self.uParSelf, self.vtSqSelf})
-
---         self.threeMomentsLBOCalc:advance(tCurr, {fIn}, { self.numDensity, self.momDensity, self.ptclEnergy,
---                                                          self.m1Correction, self.m2Correction,
---                                                          self.m0Star, self.m1Star, self.m2Star })
---	 if self.needCorrectedSelfPrimMom then
---            -- Also compute self-primitive moments uPar and vtSq.
---            self.primMomSelf:advance(tCurr, {self.numDensity, self.momDensity, self.ptclEnergy,
---                                             self.m1Correction, self.m2Correction,
---                                             self.m0Star, self.m1Star, self.m2Star}, {self.uParSelf, self.vtSqSelf})
---         else
---            -- Compute self-primitive moments with binOp updaters.
---            self.confDiv:advance(tCurr, {self.numDensity, self.momDensity}, {self.uParSelf})
---            self.confMul:advance(tCurr, {self.uParSelf, self.momDensity}, {self.numDensityAux})
---            -- Barrier over shared communicator before combine
---            Mpi.Barrier(self.grid:commSet().sharedComm)
---            self.momDensityAux:combine( 1.0/self.vDegFreedom, self.ptclEnergy,
---                                       -1.0/self.vDegFreedom, self.numDensityAux )
---            self.confDiv:advance(tCurr, {self.numDensity, self.momDensityAux}, {self.vtSqSelf})
---         end
 
          -- Indicate that moments, boundary corrections, star moments
          -- and self-primitive moments have been computed.

--- a/App/Species/KineticSpecies.lua
+++ b/App/Species/KineticSpecies.lua
@@ -361,20 +361,21 @@ end
 function KineticSpecies:createSolver(field, externalField)
    -- Set up weak multiplication and division operators.
    self.confWeakMultiply = Updater.CartFieldBinOp {
-      onGrid    = self.confGrid,   operation = "Multiply",
-      weakBasis = self.confBasis,  onGhosts  = true,
+      weakBasis = self.confBasis,  operation = "Multiply",
+      onGhosts  = true,
    }
+   local dummyConfField = self:allocMoment()
    self.confWeakDivide = Updater.CartFieldBinOp {
-      onGrid    = self.confGrid,   operation = "Divide",
-      weakBasis = self.confBasis,  onGhosts  = true,
+      weakBasis = self.confBasis,  operation = "Divide",
+      onRange   = dummyConfField:localExtRange(),  onGhosts = true,
    }
    self.confWeakDotProduct = Updater.CartFieldBinOp {
-      onGrid    = self.confGrid,   operation = "DotProduct",
-      weakBasis = self.confBasis,  onGhosts  = true,
+      weakBasis = self.confBasis,  operation = "DotProduct",
+      onGhosts = true,
    }
    self.confPhaseWeakMultiply = Updater.CartFieldBinOp {
-      onGrid    = self.grid,   fieldBasis = self.confBasis,
-      weakBasis = self.basis,  operation  = "Multiply",
+      weakBasis  = self.basis,  operation = "Multiply",
+      fieldBasis = self.confBasis,
    }
 
    -- Functions to compute fluctuations given the current moments and background,

--- a/Eq/EqBase.lua
+++ b/Eq/EqBase.lua
@@ -7,7 +7,7 @@
 
 -- system libraries
 local Proto = require "Lib.Proto"
-local ffi = require "ffi"
+local ffi   = require "ffi"
 require "Lib.ZeroUtil"
 
 ffi.cdef [[ 

--- a/Eq/Gyrofluid.lua
+++ b/Eq/Gyrofluid.lua
@@ -85,8 +85,8 @@ function Gyrofluid:setAuxFields(auxFields)
 
       -- Compose a field with J/B. Eventually we'll remove this or put it in geo.
       local weakMult = Updater.CartFieldBinOp {
-         onGrid    = self._grid,   operation = "Multiply",
-         weakBasis = self._basis,  onGhosts  = true,
+         weakBasis = self._basis,  operation = "Multiply",
+         onGhosts  = true,
       }
       self.rBmagSq = DataStruct.Field {
          onGrid        = self._grid,            

--- a/Eq/GyrofluidHeatFlux.lua
+++ b/Eq/GyrofluidHeatFlux.lua
@@ -85,8 +85,8 @@ function GyrofluidHeatFlux:setAuxFields(auxFields)
 
       -- Compose a field with 1/B^2. Eventually we'll remove this or put it in geo.
       local weakMult = Updater.CartFieldBinOp {
-         onGrid    = self._grid,   operation = "Multiply",
-         weakBasis = self._basis,  onGhosts  = true,
+         weakBasis = self._basis,  operation = "Multiply",
+         onGhosts  = true,
       }
       self.rBmagSq = DataStruct.Field {
          onGrid        = self._grid,

--- a/Updater/AnisotropicDiffusion.lua
+++ b/Updater/AnisotropicDiffusion.lua
@@ -18,9 +18,9 @@
 --------------------------------------------------------------------------------
 
 local UpdaterBase = require "Updater.Base"
-local Lin = require "Lib.Linalg"
-local Proto = require "Lib.Proto"
-local xsys = require "xsys"
+local Lin         = require "Lib.Linalg"
+local Proto       = require "Lib.Proto"
+local xsys        = require "xsys"
 
 local AnisotropicDiffusion = Proto(UpdaterBase)
 
@@ -612,7 +612,7 @@ function AnisotropicDiffusion:_forwardEuler(
 end
 
 function AnisotropicDiffusion:_advance(tCurr, inFld, outFld)
-   return self:_forwardEuler(self, tCurr, inFld, outFld)
+   return self:reduceStatusDt(self:_forwardEuler(self, tCurr, inFld, outFld))
 end
 
 return AnisotropicDiffusion

--- a/Updater/AxisymmetricFiveMomentSrc.lua
+++ b/Updater/AxisymmetricFiveMomentSrc.lua
@@ -121,7 +121,7 @@ function AxisymmetricFiveMomentSrc:_advance(tCurr, inFld, outFld)
       self._updateSrc(self, dt, xc:data(), fPtrs)
    end
 
-   return true, GKYL_MAX_DOUBLE
+   return self:reduceStatusDt(true, GKYL_MAX_DOUBLE)
 end
 
 return AxisymmetricFiveMomentSrc

--- a/Updater/AxisymmetricPhMaxwellSrc.lua
+++ b/Updater/AxisymmetricPhMaxwellSrc.lua
@@ -88,7 +88,7 @@ function AxisymmetricPhMaxwellSrc:_advance(tCurr, inFld, outFld)
       self._updateSrc(self, dt, xc:data(), fPtr)
    end
 
-   return true, GKYL_MAX_DOUBLE
+   return self:reduceStatusDt(true, GKYL_MAX_DOUBLE)
 end
 
 return AxisymmetricPhMaxwellSrc

--- a/Updater/Bc.lua
+++ b/Updater/Bc.lua
@@ -10,7 +10,6 @@ local xsys = require "xsys"
 
 -- Gkyl libraries.
 local CartDecomp     = require "Lib.CartDecomp"
-local CartFieldBinOp = require "Updater.CartFieldBinOp"
 local DataStruct     = require "DataStruct"
 local Grid           = require "Grid"
 local Lin            = require "Lib.Linalg"

--- a/Updater/BraginskiiHeatConduction.lua
+++ b/Updater/BraginskiiHeatConduction.lua
@@ -209,7 +209,7 @@ function BraginskiiHeatConduction:_forwardEuler(
 end
 
 function BraginskiiHeatConduction:_advance(tCurr, inFld, outFld)
-   return self:_forwardEuler(self, tCurr, inFld, outFld)
+   return self:reduceStatusDt(self:_forwardEuler(self, tCurr, inFld, outFld))
 end
 
 return BraginskiiHeatConduction

--- a/Updater/BraginskiiViscosityDiffusion.lua
+++ b/Updater/BraginskiiViscosityDiffusion.lua
@@ -262,7 +262,7 @@ function BraginskiiViscosityDiffusion:_forwardEuler(
 end
 
 function BraginskiiViscosityDiffusion:_advance(tCurr, inFld, outFld)
-   return self:_forwardEuler(self, tCurr, inFld, outFld)
+   return self:reduceStatusDt(self:_forwardEuler(self, tCurr, inFld, outFld))
 end
 
 return BraginskiiViscosityDiffusion

--- a/Updater/CartFieldBinOp.lua
+++ b/Updater/CartFieldBinOp.lua
@@ -22,6 +22,28 @@ local ffiC = ffi.C
 require "Lib.ZeroUtil"
 
 ffi.cdef [[
+// Type for storing preallocating memory needed in various batch
+// operations
+typedef struct gkyl_dg_bin_op_mem gkyl_dg_bin_op_mem;
+
+/**
+ * Allocate memory for use in bin op (division operator). Free using
+ * release method.
+ *
+ * @param nbatch Batch size
+ * @param neqn Number of equations in each batch
+ */
+gkyl_dg_bin_op_mem* gkyl_dg_bin_op_mem_new(size_t nbatch, size_t neqn);
+// Same as above, except for GPUs
+gkyl_dg_bin_op_mem *gkyl_dg_bin_op_mem_cu_dev_new(size_t nbatch, size_t neqn);
+
+/**
+ * Release memory needed in the bin ops.
+ *
+ * @param mem Memory to release
+ */
+void gkyl_dg_bin_op_mem_release(gkyl_dg_bin_op_mem *mem);
+
 /**
  * Same as gkyl_dg_mul_op, except operator is applied only on
  * specified range (sub-range of range containing the DG fields).
@@ -57,6 +79,25 @@ void gkyl_dg_mul_conf_phase_op_range(struct gkyl_basis *cbasis,
   struct gkyl_basis *pbasis, struct gkyl_array* pout,
   const struct gkyl_array* cop, const struct gkyl_array* pop,
   struct gkyl_range *crange, struct gkyl_range *prange);
+
+/**
+ * Same as gkyl_dg_div_op, except operator is applied only on
+ * specified range (sub-range of range containing the DG fields).
+ *
+ * @param mem Pre-allocated space for use in the division
+ * @param basis Basis functions used in expansions
+ * @param c_oop Component of output field in which to store product
+ * @param out Output DG field
+ * @param c_lop Component of left operand to use in product
+ * @param lop Left operand DG field
+ * @param c_rop Component of right operand to use in product
+ * @param rop Right operand DG field
+ * @param range Range to apply multiplication operator
+ */
+void gkyl_dg_div_op_range(gkyl_dg_bin_op_mem *mem, struct gkyl_basis basis,
+  int c_oop, struct gkyl_array* out,
+  int c_lop, const struct gkyl_array* lop,
+  int c_rop, const struct gkyl_array* rop, struct gkyl_range *range);
 ]]
 
 -- Function to check if moment name is correct.
@@ -73,16 +114,16 @@ local CartFieldBinOp = Proto(UpdaterBase)
 function CartFieldBinOp:init(tbl)
    CartFieldBinOp.super.init(self, tbl) -- Setup base object.
 
-   self._onGrid = assert(
-      tbl.onGrid, "Updater.CartFieldBinOp: Must provide grid object using 'onGrid'.")
-
    self._weakBasis = assert(
       tbl.weakBasis, "Updater.CartFieldBinOp: Must provide the weak basis object using 'weakBasis'.")
-   self._fieldBasis = tbl.fieldBasis
-   local weakBasis, fieldBasis = self._weakBasis, self._fieldBasis
-
    local op = assert(
       tbl.operation, "Updater.CartFieldBinOp: Must provide an operation using 'operation'.")
+
+   self._fieldBasis = tbl.fieldBasis
+   self.onGhosts    = xsys.pickBool(tbl.onGhosts, false)
+   self._useGPU     = xsys.pickBool(tbl.useDevice, GKYL_USE_GPU)
+
+   local weakBasis, fieldBasis = self._weakBasis, self._fieldBasis
 
    -- Positivity option disabled for now. Need to investigate bugs in kernels.
    local applyPositivity = false -- xsys.pickBool(tbl.positivity,false)   -- Positivity preserving option.
@@ -119,8 +160,6 @@ function CartFieldBinOp:init(tbl)
 		"CartFieldBinOp: Operation must be one of Multiply, Divide, DotProduct. Requested %s instead.", op))
    end
 
-   self.onGhosts = xsys.pickBool(tbl.onGhosts, false)
-
    -- Create struct containing allocated binOp arrays.
    if fieldBasis then 
       self._binOpData = ffiC.new_binOpData_t(fieldBasis:numBasis(), self._numBasis) 
@@ -128,7 +167,18 @@ function CartFieldBinOp:init(tbl)
       self._binOpData = ffiC.new_binOpData_t(self._numBasis, 0) 
    end
 
-   if op == "Multiply" then self._zero_op = op end
+   if op == "Multiply" or op == "Divide" then self._zero_op = op end
+
+   if op == "Divide" then
+      local onRange = assert(tbl.onRange, "Updater.CartFieldBinOp: Must provide the range to perform division in 'onRange'.")
+      if self._useGPU then
+         self._mem = ffi.gc(ffiC.gkyl_dg_bin_op_mem_cu_dev_new(onRange:volume(), self._numBasis),
+                            ffiC.gkyl_dg_bin_op_mem_release)
+      else
+         self._mem = ffi.gc(ffiC.gkyl_dg_bin_op_mem_new(onRange:volume(), self._numBasis),
+                            ffiC.gkyl_dg_bin_op_mem_release)
+      end
+   end
 end
 
 -- Advance method.
@@ -149,32 +199,34 @@ function CartFieldBinOp:_advance(tCurr, inFld, outFld)
       Bfld, Afld = inFld[1], inFld[2]
    end
 
+   local localuRange = self.onGhosts and uOut:localExtRange() or uOut:localRange()
    if self._zero_op and self._zero_op == "Multiply" then
-      if inFld[1]:numComponents() == inFld[2]:numComponents() then
-         ffiC.gkyl_dg_mul_op_range(self._weakBasis._zero, 0, uOut._zero, 0, Afld._zero, 0, Bfld._zero, uOut:localExtRange())
+      if self._fieldBasis then
+         -- Conf-space * phase-space multiplication.
+         local localARange = self.onGhosts and Afld:localExtRange() or Afld:localRange()
+         ffiC.gkyl_dg_mul_conf_phase_op_range(self._fieldBasis._zero, self._weakBasis._zero,
+                                              uOut._zero, Afld._zero, Bfld._zero, localARange, localuRange)
       else
-         if self._fieldBasis then
-            -- Conf-space * phase-space multiplication.
-            ffiC.gkyl_dg_mul_conf_phase_op_range(self._fieldBasis._zero, self._weakBasis._zero,
-                                                 uOut._zero, Afld._zero, Bfld._zero,
-                                                 Afld:localExtRange(), uOut:localExtRange())
-         else
-            -- Conf-space scalar * vector multiplication.
-            local nVecComp = Bfld:numComponents()/self._numBasis
-            for d = 0, nVecComp-1 do
-               ffiC.gkyl_dg_mul_op_range(self._weakBasis._zero, d, uOut._zero, 0, Afld._zero, d, Bfld._zero, uOut:localExtRange())
-            end
+         -- Conf-space scalar * scalar or scalar * vector multiplication.
+         local nVecComp = Bfld:numComponents()/self._numBasis
+         for d = 0, nVecComp-1 do
+            ffiC.gkyl_dg_mul_op_range(self._weakBasis._zero, d, uOut._zero, 0, Afld._zero, d, Bfld._zero, localuRange)
          end
       end
    
       return
    elseif self._zero_op and self._zero_op == "Divide" then
-      -- NYI
-
+      -- Conf-space scalar / scalar or vector / scalar division.
+      local nVecComp = Bfld:numComponents()/self._numBasis
+      for d = 0, nVecComp-1 do
+         ffiC.gkyl_dg_div_op_range(self._mem, self._weakBasis._zero, d, uOut._zero, d, Bfld._zero, 0, Afld._zero, localuRange)
+      end
       return
    end
 
-   local grid = self._onGrid
+   -- g2 implementation below. To be deleted eventually.
+
+   local grid = Afld:grid()
 
    -- Either the localRange is the same for Bfld and Afld,
    -- or just use the range of the phase space field,
@@ -198,23 +250,14 @@ function CartFieldBinOp:_advance(tCurr, inFld, outFld)
    -- Number of vectorial components.
    local nComp = Bfld:numComponents()/self._numBasis
 
-   local nCompEq
    -- This factor is used in the kernel to differentiate the case of
    -- scalar-vector multiplication from the vector-vector multiplication.
-   if Afld:numComponents() == Bfld:numComponents() then
-     nCompEq = 1
-   else
-     nCompEq = 0
-   end
-   if (Afld:ndim() == Bfld:ndim()) then
-     -- If the dimensions are the same assume we are doing vector-vector or
-     -- scalar-vector operations in configuration space.
-     self._BinOpCalc = self._BinOpCalcS
-   else
-     -- If dimensions are different assume we are doing multiplication of
-     -- a conf space function (scalar?) with a phase space function.
-     self._BinOpCalc = self._BinOpCalcD
-   end
+   local nCompEq = Afld:numComponents() == Bfld:numComponents() and 1 or 0
+   -- If the dimensions are the same assume we are doing vector-vector or
+   -- scalar-vector operations in configuration space.
+   -- If dimensions are different assume we are doing multiplication of
+   -- a conf space function (scalar?) with a phase space function.
+   self._BinOpCalc = (Afld:ndim() == Bfld:ndim()) and self._BinOpCalcS or self._BinOpCalcD
 
    local tId = grid:subGridSharedId() -- Local thread ID.
    -- Loop, computing binOp in each cell.
@@ -230,7 +273,6 @@ function CartFieldBinOp:_advance(tCurr, inFld, outFld)
 end
 
 function CartFieldBinOp:_advanceOnDevice(tCurr, inFld, outFld)
-   local grid = self._onGrid
    -- Multiplication: Afld * Bfld (can be scalar*scalar, vector*scalar or scalar*vector,
    --                              but in the latter Afld must be the scalar).
    -- Division:       Bfld/Afld (Afld must be a scalar function).

--- a/Updater/FemPoisson.lua
+++ b/Updater/FemPoisson.lua
@@ -57,8 +57,8 @@ function FemPoisson:init(tbl)
       }
       -- Set up weak division operator for special case when solve is algebraic.
       self.weakDivide = CartFieldBinOp {
-         onGrid    = self.grid,   operation = "Divide",
-         weakBasis = self.basis,  onGhosts  = true,
+         onRange   = self.slvr:getModifierWeight():localExtRange(),  onGhosts = true,
+         weakBasis = self.basis,  operation = "Divide",
       }
    elseif ndim == 2 then
       self.slvr = FemPerpPoisson {

--- a/Updater/FiveMomentFrictionSrc.lua
+++ b/Updater/FiveMomentFrictionSrc.lua
@@ -135,7 +135,7 @@ function FiveMomentFrictionSrc:_advance(tCurr, inFld, outFld)
       self._updateSrc(self, dt, fPtrs)
    end
 
-   return true, GKYL_MAX_DOUBLE
+   return self:reduceStatusDt(true, GKYL_MAX_DOUBLE)
 end
 
 return FiveMomentFrictionSrc

--- a/Updater/FiveMomentSrc.lua
+++ b/Updater/FiveMomentSrc.lua
@@ -336,12 +336,12 @@ end
 
 -- advance method
 function FiveMomentSrc:_advance(tCurr, inFld, outFld)
-   return self:_advanceDispatch(tCurr, inFld, outFld, "cpu")
+   return self:reduceStatusDt(self:_advanceDispatch(tCurr, inFld, outFld, "cpu"))
 end
 
 -- advance method
 function FiveMomentSrc:_advanceDevice(tCurr, inFld, outFld)
-   return self:_advanceDispatch(tCurr, inFld, outFld, "gpu")
+   return self:reduceStatusDt(self:_advanceDispatch(tCurr, inFld, outFld, "gpu"))
 end
 
 return FiveMomentSrc

--- a/Updater/StairSteppedBc.lua
+++ b/Updater/StairSteppedBc.lua
@@ -95,7 +95,7 @@ function StairSteppedBc:_advance(tCurr, inFld, outFld)
       end
    end
 
-   return true, GKYL_MAX_DOUBLE
+   return self:reduceStatusDt(true, GKYL_MAX_DOUBLE)
 end
 
 function StairSteppedBc:getDir() return self.dir end

--- a/Updater/TenMomentRelax.lua
+++ b/Updater/TenMomentRelax.lua
@@ -119,7 +119,7 @@ function TenMomentRelax:_advance(tCurr, inFld, outFld,
       self._updateRelax(self, dt, fDp, emDp, staticEmDp, myK)
    end
 
-   return true, GKYL_MAX_DOUBLE
+   return self:reduceStatusDt(true, GKYL_MAX_DOUBLE)
 end
 
 return TenMomentRelax

--- a/Updater/TenMomentSrc.lua
+++ b/Updater/TenMomentSrc.lua
@@ -226,7 +226,7 @@ function TenMomentSrc:_advance(tCurr, inFld, outFld)
       self._updateSrc(self, dt, fDp, emDp, staticEmDp, sigmaDp, auxSrcDp)
    end
 
-   return true, GKYL_MAX_DOUBLE
+   return self:reduceStatusDt(true, GKYL_MAX_DOUBLE)
 end
 
 return TenMomentSrc

--- a/Updater/WavePropagation.lua
+++ b/Updater/WavePropagation.lua
@@ -393,7 +393,7 @@ function WavePropagation:_advance(tCurr, inFld, outFld)
       local g0_status = ffi.C.gkyl_wave_prop_advance(
          self._zero, 0, dt, qOut._localRange, qIn._zero, qOut._zero)
       local success = g0_status.success == 1 and true or false
-      return success, g0_status.dt_suggested
+      return self:reduceStatusDt(success, g0_status.dt_suggested)
    end
 
    local equation = self._equation -- equation to solve
@@ -498,7 +498,7 @@ function WavePropagation:_advance(tCurr, inFld, outFld)
          end
 
          -- return if time-step was too large
-         if cfla > cflm then return false, dt*cfl/cfla end
+         if cfla > cflm then return self:reduceStatusDt(false, dt*cfl/cfla) end
 
          -- limit waves before computing second-order updates
          self:limitWaves(localRange:lower(dir), localRange:upper(dir)+1, wavesSlice, speedsSlice, onSsBnd)
@@ -527,7 +527,7 @@ function WavePropagation:_advance(tCurr, inFld, outFld)
    end
 
    self._isFirst = false -- no longer first time
-   return true, dt*cfl/cfla
+   return self:reduceStatusDt(true, dt*cfl/cfla)
 end
 
 function WavePropagation:_advanceOnDevice(tCurr, inFld, outFld)


### PR DESCRIPTION
- Plug in g0 dg_bin-ops division to g2. This made me realize that to pre-allocate the memory needed for division it is best to provide the updater with the range ahead of time, and that the grid is not needed.
- Modify the Updater/Base in two ways: a) do not require the grid to be an
  input for all updaters. This was only needed (at the Base level) to obtain communicators which are only used by Fluid/Moment Source Updaters and by the old (g2) HyperDisCont (which should no longer be used). b) Move the reduction of a status and dt to an alternative method which only Fluid/Moment Updaters call, no one else uses that.
- Simplify creation of binOp updaters throughout, since the grid is no longer
  needed and we need the range to pre-allocate memory for division.

Checked reg test vm-sheath, gk-ion-sound, gk-etg, gk-etg-5d and gk-sheath energy traces and they all looked unchanged.