### PR TITLE
Simplifications in Vlasov and Gyrokinetic apps + wrapping offset methods from g0

### DIFF
--- a/App/Collisions/CollisionsBase.lua
+++ b/App/Collisions/CollisionsBase.lua
@@ -9,6 +9,7 @@ function CollisionsBase:setName(nm)
    self.collNm = nm
 end
 function CollisionsBase:createSolver(mySpecies, externalField) end
+function CollisionsBase:createCouplingSolver(species, field, externalField) end
 function CollisionsBase:setSpeciesName(nm) self.speciesName = nm end
 function CollisionsBase:fullInit(speciesTbl) end
 function CollisionsBase:createDiagnostics(mySpecies, field) return nil end

--- a/App/Collisions/GkLBOCollisions.lua
+++ b/App/Collisions/GkLBOCollisions.lua
@@ -8,15 +8,12 @@
 
 local CollisionsBase = require "App.Collisions.CollisionsBase"
 local Constants      = require "Lib.Constants"
-local DataStruct     = require "DataStruct"
 local Proto          = require "Lib.Proto"
 local Time           = require "Lib.Time"
 local Updater        = require "Updater"
-local GkLBOconstNuEq = require "Eq.GkLBO"
 local xsys           = require "xsys"
-local Lin            = require "Lib.Linalg"
-local Mpi            = require "Comm.Mpi"
 local lume           = require "Lib.lume"
+local ffi            = require "ffi"
 
 -- GkLBOCollisions ---------------------------------------------------------------
 --
@@ -31,64 +28,55 @@ local GkLBOCollisions = Proto(CollisionsBase)
 -- construction to the fullInit() method below.
 function GkLBOCollisions:init(tbl) self.tbl = tbl end
 
--- Function to find the index of an element in table.
-local function findInd(tblIn, el)
-   for i, v in ipairs(tblIn) do
-      if v == el then
-         return i
-      end
-   end
-   return #tblIn+1    -- If not found return a number larger than the length of the table.
-end
-
-
 -- Actual function for initialization. This indirection is needed as
 -- we need the app top-level table for proper initialization.
 function GkLBOCollisions:fullInit(speciesTbl)
    local tbl = self.tbl -- previously stored table
 
+   self.selfCollisions = true -- MF: to be deleted.
    self.collKind = "GkLBO"    -- Type of collisions model. Useful at the species app level.
+
+   -- For now only cell-wise constant nu is implemented.
+   self.cellConstNu = true     -- Cell-wise constant nu?
 
    self.collidingSpecies = assert(tbl.collideWith, "App.GkLBOCollisions: Must specify names of species to collide with in 'collideWith'.")
 
-   self.selfCollisions = true -- MF: to be deleted.
-   self.varNu          = true -- MF: to be deleted.
+   -- Determine if cross-species collisions take place,
+   -- and put the names of the other colliding species in a list.
+   local selfSpecInd = lume.find(self.collidingSpecies, self.speciesName)
+   assert(selfSpecInd, "App.GkLBOCollisions: must include self-collisions.")
 
-   -- First determine if self-species and/or cross-species collisions take place,
-   -- and (if cross-collisions=true) put the names of the other colliding species in a list.
-   local selfSpecInd = findInd(self.collidingSpecies, self.speciesName)
-   if selfSpecInd < (#self.collidingSpecies+1) then
-      if #self.collidingSpecies > 1 then
-         self.crossCollisions = true             -- Apply cross-species collisions.
-         self.crossSpecies    = lume.clone(self.collidingSpecies)
-         table.remove(self.crossSpecies, selfSpecInd)
-      else
-         self.crossCollisions = false            -- Don't apply cross-species collisions.
-      end
+   if #self.collidingSpecies > 1 then
+      self.crossCollisions = true             -- Apply cross-species collisions.
+      self.crossSpecies    = lume.clone(self.collidingSpecies)
+      table.remove(self.crossSpecies, selfSpecInd)
    else
-      assert(false, "App.VmLBOCollisions: must include self-collisions.")
+      self.crossCollisions = false            -- Don't apply cross-species collisions.
    end
    
-   -- Now establish if user wants constant or spatially varying collisionality.
-   -- For constant nu, separate self and cross collision frequencies.
-   self.collFreqs = tbl.frequencies -- List of collision frequencies, if using spatially constant nu. 
+   self.collFreqs = tbl.frequencies -- List of collision frequencies.
    if self.collFreqs then
       -- Collisionality, provided by user, will remain constant in time.
       self.timeDepNu = false
+      self.calcSelfNu = function(momsIn, nuOut) GkLBOCollisions['calcSelfNuTimeConst'](self,momsIn,nuOut) end
+      self.calcCrossNu = self.crossCollisions
+         and function(species, otherNm, mOther, momsOther,
+                      vtSqOther, nuCrossSelf, nuCrossOther)
+            GkLBOCollisions['calcCrossNuTimeConst'](self,species, otherNm,
+              mOther, momsOther, vtSqOther, nuCrossSelf, nuCrossOther)
+         end
+         or nil
 
       -- Ensure that collFreqs inputs are numbers or functions.
       for iC = 1,#self.collFreqs do
          local collFreqType = type(self.collFreqs[iC])
          assert(collFreqType=="number" or collFreqType=="function",
-            "App.VmLBOCollisions: frequencies must either all be numbers, or all be functions")
+            "App.GkLBOCollisions: frequencies must either all be numbers, or all be functions")
          if (collFreqType == "number") then
             local val = self.collFreqs[iC]
             self.collFreqs[iC] = function(t, xn) return val end
          end
       end
-
-      -- For now only cell-wise constant nu is implemented.
-      self.cellConstNu  = true     -- Cell-wise constant nu?
 
       self.collFreqSelf = self.collFreqs[selfSpecInd]
       if self.crossCollisions then
@@ -98,31 +86,30 @@ function GkLBOCollisions:fullInit(speciesTbl)
    else
       -- Collisionality not provided by user. It will be calculated in time.
       self.timeDepNu = true
+      self.calcSelfNu = function(momsIn, nuOut) GkLBOCollisions['calcSelfNuTimeDep'](self,momsIn,nuOut) end
+      self.calcCrossNu = self.crossCollisions
+         and function(species, otherNm, mOther, momsOther,
+                      vtSqOther, nuCrossSelf, nuCrossOther)
+            GkLBOCollisions['calcCrossNuTimeDep'](self,species, otherNm,
+              mOther, momsOther, vtSqOther, nuCrossSelf, nuCrossOther)
+         end
+         or nil
 
-      self.charge       = speciesTbl.charge    -- Charge of this species.
-      -- For now only cell-wise constant nu is implemented.
-      self.cellConstNu  = true     -- Cell-wise constant nu?
+      self.charge = speciesTbl.charge    -- Charge of this species.
       -- If no time-constant collision frequencies provided ('frequencies'), user can specify
       -- 'normNu' list of collisionalities normalized by T_0^(3/2)/n_0 evaluated somewhere in the
       -- simulation (see Gkeyll website for exact normalization). Otherwise code compute Spitzer
       -- collisionality from scratch.
-      self.normNuIn     = tbl.normNu
+      self.normNuIn = tbl.normNu
       -- normNuSelf, epsilon0 and elemCharge may not used, but are
       -- initialized to avoid if-statements in advance method.
       if self.normNuIn then
-         self.userInputNormNu = true
          self.normNuSelf  = self.normNuIn[selfSpecInd]
          if self.crossCollisions then
-            self.normNuCross = lume.clone(self.normNuIn)
-            table.remove(self.normNuCross, selfSpecInd)
-         end
-      else
-         self.userInputNormNu = false
-         self.normNuSelf       = 0.0
-         if self.crossCollisions then
-            self.normNuCross = lume.clone(self.collidingSpecies)
-            table.remove(self.normNuCross, selfSpecInd)
-            for i, _ in ipairs(self.normNuCross) do self.normNuCross[i] = 0.0 end
+            self.normNuCrossIn = lume.clone(self.normNuIn)
+            table.remove(normNuCrossIn, selfSpecInd)
+            self.normNuCross = {}  -- Need a name-value pairs table.
+            for i, nm in ipairs(self.crossSpecies) do self.normNuCross[nm] = normNuCrossIn[i] end
          end
       end
       -- Check for constants epsilon_0, elementary charge e, and Planck's constant/2pi. If not use default value.
@@ -133,19 +120,20 @@ function GkLBOCollisions:fullInit(speciesTbl)
 
    if self.crossCollisions then
       self.charge     = speciesTbl.charge    -- Charge of this species.
+      -- Can specify 'betaGreene' free parameter in Grene cross-species collisions.
       self.betaGreene = tbl.betaGreene and tbl.betaGreene or 0.0
    end
 
-   self.nuFrac = tbl.nuFrac and tbl.nuFrac or 1.0
-
    self.mass = speciesTbl.mass   -- Mass of this species.
+
+   self.nuFrac = tbl.nuFrac and tbl.nuFrac or 1.0
 
    self.cfl = 0.0    -- Will be replaced.
 
    self.timers = {nonSlvr = 0.}
 end
 
-function GkLBOCollisions:setName(nm) self.name = nm end
+function GkLBOCollisions:setName(nm) self.name = self.speciesName.."_"..nm end
 function GkLBOCollisions:setSpeciesName(nm) self.speciesName = nm end
 function GkLBOCollisions:setCfl(cfl) self.cfl = cfl end
 function GkLBOCollisions:setConfBasis(basis) self.confBasis = basis end
@@ -154,192 +142,220 @@ function GkLBOCollisions:setPhaseBasis(basis) self.phaseBasis = basis end
 function GkLBOCollisions:setPhaseGrid(grid) self.phaseGrid = grid end
 
 function GkLBOCollisions:createSolver(mySpecies, externalField)
-   self.vDim = self.phaseGrid:ndim() - self.confGrid:ndim()
-
-   -- Number of physical velocity dimensions.
-   self.vDimPhys = 1.0
-   if self.vDim == 2 then self.vDimPhys = 3.0 end
-
-   -- Maximum velocity of the velocity grid (and its square).
-   self.vParMax   = self.phaseGrid:upper(self.confGrid:ndim()+1)
-   self.vParMaxSq = self.vParMax^2
-
-   -- Collisionality, nu, summed over all species pairs.
-   self.nuSum = DataStruct.Field {
-      onGrid        = self.confGrid,
-      numComponents = self.confBasis:numBasis(),
-      ghost         = {1, 1},
-   }
-   -- Parallel flow velocity times collisionality, summed over species.
-   self.nuUParSum = DataStruct.Field {
-      onGrid        = self.confGrid,
-      numComponents = self.confBasis:numBasis(),
-      ghost         = {1, 1},
-   }
-   -- Thermal speed squared times collisionality, summed over species.
-   self.nuVtSqSum = DataStruct.Field {
-      onGrid        = self.confGrid,
-      numComponents = self.confBasis:numBasis(),
-      ghost         = {1, 1},
-   }
+   local vDim = self.phaseGrid:ndim() - self.confGrid:ndim()
 
    -- Inverse of background magnetic field.
    self.bmag    = externalField.geo.bmag
    -- Inverse of background magnetic field.
    self.bmagInv = externalField.geo.bmagInv
       
-   -- Zero-flux BCs in the velocity dimensions.
-   local zfd = { }
-   for d = 1, self.vDim do zfd[d] = self.confGrid:ndim() + d end
-
    -- Self-species collisionality, which varies in space.
-   self.nuVarXSelf = DataStruct.Field {
-      onGrid        = self.confGrid,
-      numComponents = self.confBasis:numBasis(),
-      ghost         = {1, 1},
+   self.nuSelf = mySpecies:allocMoment()
+   -- Allocate fields to store self-species primitive moments.
+   self.uParSelf = mySpecies:allocMoment()
+   self.vtSqSelf = mySpecies:allocMoment()
+   -- Allocate fields for boundary corrections.
+   self.boundCorrs = mySpecies:allocVectorMoment(2)
+
+   local vbounds = ffi.new("double[4]")
+   for i = 1, vDim do
+      vbounds[i-1]      = self.phaseGrid:lower(self.confGrid:ndim()+i)
+      vbounds[i-1+vDim] = self.phaseGrid:upper(self.confGrid:ndim()+i)
+   end
+   self.primMomSelf = Updater.SelfPrimMoments {
+      onGrid     = self.phaseGrid,   operator = "GkLBO",
+      phaseBasis = self.phaseBasis,  vbounds  = vbounds,
+      confBasis  = self.confBasis,   mass     = self.mass,
    }
+
+   local projectUserNu
    if self.timeDepNu then
+      self.m0Self = mySpecies:allocMoment()  -- M0, to be extracted from fiveMoments.
       -- Updater to compute spatially varying (Spitzer) nu.
       self.spitzerNu = Updater.SpitzerCollisionality {
-         onGrid           = self.confGrid,         elemCharge = self.elemCharge,
-         confBasis        = self.confBasis,        epsilon0   = self.epsilon0,
-         useCellAverageNu = self.cellConstNu,      hBar       = self.hBar,
-         willInputNormNu  = self.userInputNormNu,  nuFrac     = self.nuFrac,
+         onGrid           = self.confGrid,     elemCharge = self.elemCharge,
+         confBasis        = self.confBasis,    epsilon0   = self.epsilon0,
+         useCellAverageNu = self.cellConstNu,  hBar       = self.hBar,
+         willInputNormNu  = self.normNuIn,     nuFrac     = self.nuFrac,
       }
    else
-      local projectUserNu = Updater.ProjectOnBasis {
+      projectUserNu = Updater.ProjectOnBasis {
          onGrid = self.confGrid,   evaluate = self.collFreqSelf,
          basis  = self.confBasis,  onGhosts = false
       }
-      projectUserNu:advance(0.0, {}, {self.nuVarXSelf})
+      projectUserNu:advance(0.0, {}, {self.nuSelf})
    end
+
    -- Weak multiplication to multiply nu(x) with uPar or vtSq.
    self.confMul = Updater.CartFieldBinOp {
       weakBasis = self.confBasis,  operation = "Multiply",
    }
-   self.equation = {}
    self.collisionSlvr = Updater.GkLBO {
       onGrid     = self.phaseGrid,   confBasis = self.confBasis,
-      phaseBasis = self.phaseBasis,  confRange = self.nuSum:localRange(),
+      phaseBasis = self.phaseBasis,  confRange = self.nuSelf:localRange(),
       mass       = self.mass,
    }
+
    if self.crossCollisions then
-      -- Temporary collisionality fields.
-      self.nuCrossSelf = DataStruct.Field {
-         onGrid        = self.confGrid,
-         numComponents = self.confBasis:numBasis(),
-         ghost         = {1, 1},
-      }
-      self.nuCrossOther = DataStruct.Field {
-         onGrid        = self.confGrid,
-         numComponents = self.confBasis:numBasis(),
-         ghost         = {1, 1},
-      }
-      -- Cross-species uPar and vtSq multiplied by collisionality.
-      self.nuUParCross = DataStruct.Field {
-         onGrid        = self.confGrid,
-         numComponents = self.confBasis:numBasis(),
-         ghost         = {1, 1},
-      }
-      self.nuVtSqCross = DataStruct.Field {
-         onGrid        = self.confGrid,
-         numComponents = self.confBasis:numBasis(),
-         ghost         = {1, 1},
-      }
+      -- Cross-collision u and vtSq multiplied by collisionality.
+      self.nuUParCross = mySpecies:allocMoment()
+      self.nuVtSqCross = mySpecies:allocMoment()
       -- Prefactor m_0s*delta_s in cross primitive moment calculation.
-      self.m0s_deltas = DataStruct.Field {
-         onGrid        = self.confGrid,
-         numComponents = self.confBasis:numBasis(),
-         ghost         = {1, 1},
-      }
-      self.m0s_deltas_den = DataStruct.Field {
-         onGrid        = self.confGrid,
-         numComponents = self.confBasis:numBasis(),
-         ghost         = {1, 1},
-      }
+      self.m0s_deltas     = mySpecies:allocMoment()
+      self.m0s_deltas_den = mySpecies:allocMoment()
       -- Weak division to compute the pre-factor in cross collision primitive moments.
       self.confDiv = Updater.CartFieldBinOp {
          weakBasis = self.confBasis,           operation = "Divide",
-         onRange   = self.nuSum:localRange(),  onGhosts  = false,
+         onRange   = self.nuSelf:localRange(),  onGhosts  = false,
       }
       -- Updater to compute cross-species primitive moments.
       self.primMomCross = Updater.CrossPrimMoments {
          onGrid     = self.confGrid,    betaGreene       = self.betaGreene,
-         phaseBasis = self.phaseBasis,  varyingNu        = self.varNu,
+         phaseBasis = self.phaseBasis,  varyingNu        = true,
          confBasis  = self.confBasis,   useCellAverageNu = self.cellConstNu,
          operator   = "GkLBO",
       }
+
+      -- Allocate (and assign if needed) cross-species collision frequencies,
+      -- and cross primitive moments.
+      self.nuCross, self.uParCross, self.vtSqCross = {}, {}, {}
+      -- Flag to indicate if cross collision frequency has been computed.
+      self.crossFlags = self.timeDepNu and {} or nil
+      for ispec, otherNm in ipairs(self.crossSpecies) do
+         self.nuCross[otherNm] = mySpecies:allocMoment()
+         if self.timeDepNu then
+            self.crossFlags[otherNm] = false
+         else
+            projectUserNu:setFunc(self.collFreqCross[ispec])
+            projectUserNu:advance(0.0, {}, {self.nuCross[otherNm]})
+            self.nuCross[otherNm]:write(string.format("%s_nu-%s_%d.bp",self.speciesName,otherNm,0),0.0,0)
+         end
+         self.uParCross[otherNm] = mySpecies:allocMoment()
+         self.vtSqCross[otherNm] = mySpecies:allocMoment()
+      end
+
+      self.m0Other = self.timeDepNu and mySpecies:allocMoment() or nil  -- M0, to be extracted from fiveMoments.
    end
 
-   -- Number of cells in which number density was negative (somewhere).
-   self.primMomLimitCrossingsL = DataStruct.DynVector {
-      numComponents = 1,
-   }
-   self.primMomLimitCrossingsG = DataStruct.DynVector {
-      numComponents = 1,
-   }
+   -- Collisionality, nu, summed over all species pairs.
+   self.nuSum = mySpecies:allocMoment()
+   -- Sum of flow velocities multiplied by respective collisionalities.
+   self.nuUParSum = mySpecies:allocMoment()
+   -- Sum of squared thermal speeds, vthSq=T/m, multiplied by respective collisionalities.
+   self.nuVtSqSum = mySpecies:allocMoment()
+end
+
+function GkLBOCollisions:createCouplingSolver(species, field, externalField)
+   -- Store a pointer to the collision app in the other species, so we know
+   -- where to find things stored in the collision app (e.g. primitive momemts, nu).
+   if self.crossCollisions then
+      self.collAppOther = {}
+      for _, nm in ipairs(self.crossSpecies) do
+         for _, app in pairs(species[nm].collisions) do
+            if app.collKind == self.collKind then self.collAppOther[nm] = app end
+         end
+      end
+   end
+end
+
+function GkLBOCollisions:boundaryCorrections() return self.boundCorrs end
+function GkLBOCollisions:selfPrimitiveMoments() return self.uParSelf, self.vtSqSelf end
+function GkLBOCollisions:crossFrequencies(speciesName) return self.nuCross[speciesName] end
+function GkLBOCollisions:crossNormNu(speciesName) return self.normNuCross[speciesName] end
+function GkLBOCollisions:crossFlags(speciesName) return self.crossFlags[speciesName] end
+
+function GkLBOCollisions:createDiagnostics(mySpecies, field)
+   -- Create source diagnostics.
+   self.diagnostics = nil
+   if self.tbl.diagnostics then
+      self.diagnostics = DiagsApp{implementation = GkLBODiagsImpl()}
+      self.diagnostics:fullInit(mySpecies, field, self)
+   end
+   return self.diagnostics
+end
+
+function GkLBOCollisions:calcCouplingMoments(tCurr, rkIdx, species)
+   -- Compute self-primitive moments u and vtSq.
+   local fIn      = species[self.speciesName]:rkStepperFields()[rkIdx]
+   local momsSelf = species[self.speciesName]:fluidMoments()
+
+   self.primMomSelf:advance(tCurr, {momsSelf, fIn, self.boundCorrs},
+                            {self.uParSelf, self.vtSqSelf})
+end
+
+function GkLBOCollisions:calcSelfNuTimeConst(momsSelf, nuOut) nuOut:copy(self.nuSelf) end
+
+function GkLBOCollisions:calcSelfNuTimeDep(momsSelf, nuOut)
+   -- Compute the Spitzer collisionality.
+   self.m0Self:combineOffset(1., momsSelf, 0)
+   self.spitzerNu:advance(tCurr, {self.charge, self.mass, self.m0Self, self.vtSqSelf,
+                                  self.charge, self.mass, self.m0Self, self.vtSqSelf,
+                                  self.normNuSelf, self.bmag}, {nuOut})
+end
+
+function GkLBOCollisions:calcCrossNuTimeConst(species, otherNm,
+   mOther, momsOther, vtSqOther, nuCrossSelf, nuCrossOther) end
+
+function GkLBOCollisions:calcCrossNuTimeDep(species, otherNm,
+   mOther, momsOther, vtSqOther, nuCrossSelf, nuCrossOther)
+
+   -- Compute the Spitzer collisionality if another species hasn't already done so.
+   local chargeOther     = species[otherNm]:getCharge()
+   local crossFlagsSelf  = self.crossFlags[otherNm]
+   local crossFlagsOther = self.collAppOther[otherNm]:crossFlags(self.speciesName)
+   self.m0Other:combineOffset(1., momsOther, 0)
+   if not crossFlagsSelf then
+      local crossNormNuSelf = self.normNuCross[otherNm]
+      self.spitzerNu:advance(tCurr, {self.charge, self.mass, self.m0Self, self.vtSqSelf,
+                                     chargeOther, mOther, self.m0Other, vtSqOther, crossNormNuSelf},
+                                    {nuCrossSelf})
+      crossFlagsSelf = true
+   end
+   if not crossFlagsOther then
+      local crossNormNuOther = self.collAppOther[otherNm]:crossNormNu(self.speciesName)
+      self.spitzerNu:advance(tCurr, {chargeOther, mOther, self.m0Other, vtSqOther,
+                                     self.charge, self.mass, self.m0Self, self.vtSqSelf, crossNormNuOther},
+                                    {nuCrossOther})
+      crossFlagsOther = true
+   end
 end
 
 function GkLBOCollisions:advance(tCurr, fIn, species, out)
+   local tmNonSlvrStart = Time.clock()
 
    local fRhsOut = out[1]
    local cflRateByCell = out[2]
 
-   local tmNonSlvrStart = Time.clock()
-   self.equation.primMomCrossLimit = 0.0
+   -- Fetch coupling moments of this species.
+   local momsSelf = species[self.speciesName]:fluidMoments()
 
-   -- Fetch coupling moments and primitive moments of this species.
-   local momsSelf    = species[self.speciesName]:fluidMoments()
-   local primMomSelf = species[self.speciesName]:selfPrimitiveMoments()
-
-   if self.timeDepNu then
-      -- Compute the Spitzer collisionality.
-      self.spitzerNu:advance(tCurr, {self.charge, self.mass, momsSelf[1], primMomSelf[2],
-                                     self.charge, self.mass, momsSelf[1], primMomSelf[2], 
-                                     self.normNuSelf, self.bmag}, {self.nuSum})
-   else
-      self.nuSum:copy(self.nuVarXSelf)
-   end
-   self.confMul:advance(tCurr, {self.nuSum, primMomSelf[1]}, {self.nuUParSum})
-   self.confMul:advance(tCurr, {self.nuSum, primMomSelf[2]}, {self.nuVtSqSum})
+   self.calcSelfNu(momsSelf, self.nuSum)
+   self.confMul:advance(tCurr, {self.nuSum, self.uParSelf}, {self.nuUParSum})
+   self.confMul:advance(tCurr, {self.nuSum, self.vtSqSelf}, {self.nuVtSqSum})
 
    if self.crossCollisions then
 
-      local bCorrectionsSelf = species[self.speciesName]:boundaryCorrections()
+      local bCorrectionsSelf = self.boundCorrs
 
-      for sInd, otherNm in ipairs(self.crossSpecies) do
+      for _, otherNm in ipairs(self.crossSpecies) do
 
-         local mOther            = species[otherNm]:getMass()
-         local momsOther         = species[otherNm]:fluidMoments()
-         local primMomOther      = species[otherNm]:selfPrimitiveMoments()
-         local bCorrectionsOther = species[otherNm]:boundaryCorrections()
+         local mOther               = species[otherNm]:getMass()
+         local momsOther            = species[otherNm]:fluidMoments()
+         local uParOther, vtSqOther = self.collAppOther[otherNm]:selfPrimitiveMoments()
 
-         if self.timeDepNu then
-            -- Compute the collisionality if another species hasn't already done so.
-            local chargeOther = species[otherNm]:getCharge()
-            if (not species[self.speciesName].momentFlags[6][otherNm]) then
-               self.spitzerNu:advance(tCurr, {self.charge, self.mass, momsSelf[1], primMomSelf[2],
-                                              chargeOther, mOther, momsOther[1], primMomOther[2],
-                                              self.normNuCross[sInd], self.bmag},
-                                             {species[self.speciesName].nuVarXCross[otherNm]})
-               species[self.speciesName].momentFlags[6][otherNm] = true
-            end
-            if (not species[otherNm].momentFlags[6][self.speciesName]) then
-               self.spitzerNu:advance(tCurr, {chargeOther, mOther, momsOther[1], primMomOther[2],
-                                              self.charge, self.mass, momsSelf[1], primMomSelf[2],
-                                              species[otherNm].collPairs[otherNm][self.speciesName].normNu, self.bmag},
-                                             {species[otherNm].nuVarXCross[self.speciesName]})
-               species[otherNm].momentFlags[6][self.speciesName] = true
-            end
-         end
-         self.nuCrossSelf:copy(species[self.speciesName].nuVarXCross[otherNm])
-         self.nuCrossOther:copy(species[otherNm].nuVarXCross[self.speciesName])
+         local nuCrossSelf  = self.nuCross[otherNm]
+         local nuCrossOther = self.collAppOther[otherNm]:crossFrequencies(self.speciesName)
+
+         -- Calculate time-dependent collision frequency if needed.
+         self.calcCrossNu(species, otherNm, mOther, momsOther, vtSqOther,
+                          nuCrossSelf, nuCrossOther)
+
 
          -- Compose the pre-factor:
          --   m0_s*delta_s = m0_s*(2*m_r*m0_r*nu_rs/(m_s*m0_s*nu_sr+m_r*m0_r*nu_rs))
          local deltas_num, deltas_den = self.m0s_deltas, self.m0s_deltas_den
-         self.confMul:advance(tCurr, {momsSelf, self.nuCrossSelf, 1}, {deltas_den})
-         self.confMul:advance(tCurr, {momsOther, self.nuCrossOther, 1}, {deltas_num})
+         self.confMul:advance(tCurr, {momsSelf, nuCrossSelf, 1}, {deltas_den})
+         self.confMul:advance(tCurr, {momsOther, nuCrossOther, 1}, {deltas_num})
          deltas_den:scale(self.mass)
          deltas_den:accumulate(mOther, deltas_num)
          deltas_num:scale(2.*mOther)
@@ -347,16 +363,15 @@ function GkLBOCollisions:advance(tCurr, fIn, species, out)
          self.confDiv:advance(tCurr, {deltas_den, deltas_num}, {self.m0s_deltas})
 
          -- Cross-primitive moments for the collision of these two species has not been computed.
-         self.primMomCross:advance(tCurr, {self.mass, self.nuCrossSelf, momsSelf, primMomSelf, bCorrectionsSelf,
-                                           mOther, self.nuCrossOther, momsOther, primMomOther, bCorrectionsOther,
+         self.primMomCross:advance(tCurr, {self.mass, nuCrossSelf, momsSelf, self.uParSelf, self.vtSqSelf, bCorrectionsSelf,
+                                           mOther, nuCrossOther, momsOther, uParOther, vtSqOther, bCorrectionsOther,
                                            self.m0s_deltas},
-                                          {species[self.speciesName].uParCross[otherNm], species[self.speciesName].vtSqCross[otherNm]})
+                                          {self.uParCross[otherNm], self.vtSqCross[otherNm]})
 
+         self.confMul:advance(tCurr, {nuCrossSelf, self.uParCross[otherNm]}, {self.nuUParCross})
+         self.confMul:advance(tCurr, {nuCrossSelf, self.vtSqCross[otherNm]}, {self.nuVtSqCross})
 
-         self.confMul:advance(tCurr, {self.nuCrossSelf, species[self.speciesName].uParCross[otherNm]}, {self.nuUParCross})
-         self.confMul:advance(tCurr, {self.nuCrossSelf, species[self.speciesName].vtSqCross[otherNm]}, {self.nuVtSqCross})
-
-         self.nuSum:accumulate(1.0, self.nuCrossSelf)
+         self.nuSum:accumulate(1.0, nuCrossSelf)
          self.nuUParSum:accumulate(1.0, self.nuUParCross)
          self.nuVtSqSum:accumulate(1.0, self.nuVtSqCross)
 
@@ -370,14 +385,7 @@ function GkLBOCollisions:advance(tCurr, fIn, species, out)
       tCurr, {fIn, self.bmagInv, self.nuUParSum, self.nuVtSqSum, self.nuSum}, {fRhsOut, cflRateByCell})
 end
 
-function GkLBOCollisions:write(tm, frame)
-   Mpi.Allreduce(self.primMomLimitCrossingsL:data():data(), 
-                 self.primMomLimitCrossingsG:data():data(), self.primMomLimitCrossingsG:size()*2,
-                 Mpi.DOUBLE, Mpi.SUM, self.confGrid:commSet().comm)
-   self.primMomLimitCrossingsG:write(string.format("%s_%s.bp", self.speciesName, "primMomLimitCrossings"), tm, frame)
-   self.primMomLimitCrossingsL:clear(0.0)
-   self.primMomLimitCrossingsG:clear(0.0)
-end
+function GkLBOCollisions:write(tm, frame) end
 
 function GkLBOCollisions:totalTime() return self.collisionSlvr.totalTime + self.timers.nonSlvr end
 

--- a/App/PlasmaOnCartGrid.lua
+++ b/App/PlasmaOnCartGrid.lua
@@ -295,6 +295,9 @@ local function buildApplication(self, tbl)
    end   
    -- Create field solver (sometimes requires species solver to have been created).
    field:createSolver(species, externalField)
+
+   -- Some objects require an additional createSolver step after self-species
+   -- solvers are created due to cross-species interactions.
    for _, s in lume.orderedIter(species) do
       s:createCouplingSolver(species, field, externalField)
    end

--- a/App/Species/FuncVlasovSpecies.lua
+++ b/App/Species/FuncVlasovSpecies.lua
@@ -69,10 +69,6 @@ function FuncVlasovSpecies:alloc(nRkDup)
    self.momDensity = self:allocVectorMoment(self.vdim)
 end
 
-function FuncVlasovSpecies:allocMomCouplingFields()
-   return { currentDensity = self:allocVectorMoment(self.vdim) }
-end
-
 function FuncVlasovSpecies:createSolver()
    self.momDensitySlvr = Updater.ProjectOnBasis {
       onGrid   = self.confGrid,

--- a/DataStruct/ZeroArray.lua
+++ b/DataStruct/ZeroArray.lua
@@ -138,6 +138,20 @@ struct gkyl_array* gkyl_array_accumulate(struct gkyl_array *out,
   double a, const struct gkyl_array *inp);
 
 /**
+ * Compute out = out + a*inp[coff] where coff is a component-offset if
+ * out->ncomp < inp->ncomp, or out[coff] = out[coff]+ a*inp if
+ * out->ncomp > inp->ncomp. Returns out.
+ *
+ * @param out Output array
+ * @param a Factor to multiply input array
+ * @param inp Input array
+ * @param coff Component offset
+ * @return out array
+ */
+struct gkyl_array* gkyl_array_accumulate_offset(struct gkyl_array *out,
+  double a, const struct gkyl_array *inp, int coff);
+
+/**
  * Set out = a*inp. Returns out.
  *
  * @param out Output array
@@ -147,6 +161,20 @@ struct gkyl_array* gkyl_array_accumulate(struct gkyl_array *out,
  */
 struct gkyl_array* gkyl_array_set(struct gkyl_array *out,
   double a, const struct gkyl_array *inp);
+
+/**
+ * Set out = a*inp[coff] where coff is a component-offset if
+ * out->ncomp < inp->ncomp, or out[coff] = a*inp if
+ * out->ncomp > inp->ncomp. Returns out.
+ *
+ * @param out Output array
+ * @param a Factor to multiply input array
+ * @param inp Input array
+ * @param coff Component offset
+ * @return out array
+ */
+struct gkyl_array* gkyl_array_set_offset(struct gkyl_array *out,
+  double a, const struct gkyl_array *inp, int coff);
 
 /**
  * Scale out = a*out. Returns out.
@@ -182,6 +210,20 @@ struct gkyl_array* gkyl_array_accumulate_range(struct gkyl_array *out,
   double a, const struct gkyl_array *inp, struct gkyl_range range);
 
 /**
+ * Compute out = out + a*inp[coff] where coff is a component-offset if
+ * out->ncomp < inp->ncomp, or out[coff] = out[coff]+ a*inp if
+ * out->ncomp > inp->ncomp, over a range of indices. Returns out.
+ *
+ * @param out Output array
+ * @param a Factor to multiply input array
+ * @param inp Input array
+ * @param coff Component offset
+ * @return out array
+ */
+struct gkyl_array* gkyl_array_accumulate_offset_range(struct gkyl_array *out,
+  double a, const struct gkyl_array *inp, int coff, struct gkyl_range range);
+
+/**
  * Set out = a*inp. Returns out.
  *
  * @param out Output array
@@ -192,6 +234,20 @@ struct gkyl_array* gkyl_array_accumulate_range(struct gkyl_array *out,
  */
 struct gkyl_array* gkyl_array_set_range(struct gkyl_array *out,
   double a, const struct gkyl_array *inp, struct gkyl_range range);
+
+/**
+ * Set out = a*inp[coff] where coff is a component-offset if
+ * out->ncomp < inp->ncomp, or out[coff] = a*inp if
+ * out->ncomp > inp->ncomp, over a range of indices. Returns out.
+ *
+ * @param out Output array
+ * @param a Factor to multiply input array
+ * @param inp Input array
+ * @return out array
+ * @param range Range specifying region to set
+ */
+struct gkyl_array* gkyl_array_set_offset_range(struct gkyl_array *out,
+  double a, const struct gkyl_array *inp, int coff, struct gkyl_range range);
 
 /**
  * Scale out = a*ut. Returns out.
@@ -350,11 +406,26 @@ local array_fn = {
    set = function (self, val, fld)
       ffiC.gkyl_array_set(self, val, fld)
    end,
+   setOffset = function (self, val, fld, off)
+      ffiC.gkyl_array_set_offset(self, val, fld, off)
+   end,
    accumulate = function (self, val, fld)
       ffiC.gkyl_array_accumulate(self, val, fld)
    end,
+   accumulateOffset = function (self, val, fld, off)
+      ffiC.gkyl_array_accumulate_offset(self, val, fld, off)
+   end,
+   setRange = function (self, val, fld, rng)
+      ffiC.gkyl_array_set_range(self, val, fld, rng)
+   end,
+   setOffsetRange = function (self, val, fld, off, rng)
+      ffiC.gkyl_array_set_offset_range(self, val, fld, off, rng)
+   end,
    accumulateRange = function (self, val, fld, rng)
       ffiC.gkyl_array_accumulate_range(self, val, fld, rng)
+   end,
+   accumulateOffsetRange = function (self, val, fld, off, rng)
+      ffiC.gkyl_array_accumulate_offset_range(self, val, fld, off, rng)
    end,
    scale = function (self, val)
       ffiC.gkyl_array_scale(self, val)

--- a/Regression/vm-bodyforce/rt-neutral-bodyforce.lua
+++ b/Regression/vm-bodyforce/rt-neutral-bodyforce.lua
@@ -12,7 +12,7 @@ endTime = 0.5
 
 App = Vlasov.App {
    tEnd = 1.0,
-   nFrame = 10,
+   nFrame = 1,
    lower = {-L},
    upper = {L},
    cells = {16},
@@ -31,22 +31,21 @@ App = Vlasov.App {
 
       init = Vlasov.MaxwellianProjection {
          density = function (t, xn)
-            local x, y = xn[1], xn[2]
-            return n0*math.exp(-(x*x)/(2*0.5*0.5) + -(y*y)/(2*0.5*0.5))
+            local x = xn[1]
+            return n0*math.exp(-(x*x)/(2*0.5*0.5))
          end,
-         driftSpeed = {0.0,0.0},
+         driftSpeed = {0.0},
          temperature = T0,
-         isInit = true,
       },   
    
-   evolve = true,
-   diagnostics = {"M0", "M1i", "M2"},   
-
-   vlasovExtForceFunc = function(t, xn)
-      return -5.0, 0.0, 0.0
-   end,
+      evolve = true,
+      diagnostics = {"M0", "M1i", "M2"},   
+      
+      vlasovExtForceFunc = function(t, xn)
+         return -5.0, 0.0, 0.0
+      end,
    },   
 
-   }
+}
 
 App:run()

--- a/Updater/CrossPrimMoments.lua
+++ b/Updater/CrossPrimMoments.lua
@@ -180,15 +180,15 @@ function CrossPrimMoments:_advance(tCurr, inFld, outFld)
 
       local mSelf, nuSelf   = inFld[1], inFld[2]
       local momsSelf        = inFld[3]
-      local uSelf, vtSqSelf = inFld[4][1], inFld[4][2]
-      local bCorrsSelf      = inFld[5]
+      local uSelf, vtSqSelf = inFld[4], inFld[5]
+      local bCorrsSelf      = inFld[6]
 
-      local mOther, nuOther   = inFld[6], inFld[7]
-      local momsOther         = inFld[8]
-      local uOther, vtSqOther = inFld[9][1], inFld[9][2]
-      local bCorrsOther       = inFld[10]
+      local mOther, nuOther   = inFld[7], inFld[8]
+      local momsOther         = inFld[9]
+      local uOther, vtSqOther = inFld[10], inFld[11]
+      local bCorrsOther       = inFld[12]
 
-      local m0sdeltas = inFld[11]
+      local m0sdeltas = inFld[13]
 
       local uCrossSelf, vtSqCrossSelf = outFld[1], outFld[2]
 
@@ -419,15 +419,15 @@ function CrossPrimMoments:_advanceOnDevice(tCurr, inFld, outFld)
 
    local mSelf, nuSelf   = inFld[1], inFld[2]
    local momsSelf        = inFld[3]
-   local uSelf, vtSqSelf = inFld[4][1], inFld[4][2]
-   local bCorrsSelf      = inFld[5]
+   local uSelf, vtSqSelf = inFld[4], inFld[5]
+   local bCorrsSelf      = inFld[6]
 
-   local mOther, nuOther   = inFld[6], inFld[7]
-   local momsOther         = inFld[8]
-   local uOther, vtSqOther = inFld[9][1], inFld[9][2]
-   local bCorrsOther       = inFld[10]
+   local mOther, nuOther   = inFld[7], inFld[8]
+   local momsOther         = inFld[9]
+   local uOther, vtSqOther = inFld[10], inFld[11]
+   local bCorrsOther       = inFld[12]
 
-   local m0sdeltas = inFld[11]
+   local m0sdeltas = inFld[13]
 
    local uCrossSelf, vtSqCrossSelf = outFld[1], outFld[2]
 

--- a/Updater/SeparateVectorComponents.lua
+++ b/Updater/SeparateVectorComponents.lua
@@ -39,4 +39,18 @@ function SeparateVectorComponents:_advance(tCurr, inFld, outFld)
 
 end
 
+function SeparateVectorComponents:_advanceOnDevice(tCurr, inFld, outFld)
+   -- Copy input fields from device -> host.
+   for _, fld in ipairs(inFld) do
+      if type(fld)=="table" and fld._zero then fld:copyDeviceToHost() end
+   end
+    -- Also copy output fields in case they are inputs too,
+    -- or are incremented rather than overwritten.
+   for _, fld in ipairs(outFld) do
+      if type(fld)=="table" and fld._zero then fld:copyDeviceToHost() end
+   end
+
+   self:_advance(tCurr, inFld, outFld)
+end
+
 return SeparateVectorComponents


### PR DESCRIPTION
Performed some serious simplifications in the Vlasov and GK apps, primarily to

1. Get rid of support for arbitrary collision combinations. Now we only support either self-collisions only, or self-collisions with cross collisions where all species collide with each other.
2. Remove if-statements that existed in the time loop (i.e. in calcCouplingMoments and advance).

Also wrap the array/CartField offset methods from g0.
Note that 1. above will have to be re-examined when we re-implement the neutral model, because in that case not all species collide with each other. But the main point is that if species A collides with species B, we must have species B collide with species A, and that will still be true in neutral models.

Checked many regression tests on both CPU and GPU and they all look good.

