### PR TITLE
Revamp our wrapping of MPI_Request and MPI_Status.

### DIFF
--- a/Comm/GkylMpiFuncs.cpp
+++ b/Comm/GkylMpiFuncs.cpp
@@ -70,25 +70,43 @@ GET_INT_OBJECT(MPI_UNDEFINED);
 GET_INT_OBJECT(MPI_ORDER_C);
 GET_INT_OBJECT(MPI_ORDER_FORTRAN);
 
-// utility functions
-void
-GkMPI_fillStatus(const MPI_Status* inStatus, int *outStatus) {
-  outStatus[0] = inStatus->MPI_SOURCE;
-  outStatus[1] = inStatus->MPI_TAG;
-  outStatus[2] = inStatus->MPI_ERROR;
+// Functions to allocate and free structs holding requests and statuses.
+void gkyl_mpi_request_alloc(gkyl_mpi_request *rs, int num) {
+  rs->req = (MPI_Request *) malloc(num*sizeof(MPI_Request));
+}
+void gkyl_mpi_request_release(gkyl_mpi_request *rs) {
+  free(rs->req);
+}
+void gkyl_mpi_status_alloc(gkyl_mpi_status *ss, int num) {
+  ss->stat = (MPI_Status *) malloc(num*sizeof(MPI_Status));
+}
+void gkyl_mpi_status_release(gkyl_mpi_status *ss) {
+  free(ss->stat);
+}
+void gkyl_mpi_request_status_alloc(gkyl_mpi_request_status *rss, int num) {
+  rss->req = (MPI_Request *) malloc(num*sizeof(MPI_Request));
+  rss->stat = (MPI_Status *) malloc(num*sizeof(MPI_Status));
+}
+void gkyl_mpi_request_status_release(gkyl_mpi_request_status *rss) {
+  free(rss->req);
+  free(rss->stat);
 }
 
-void
-GkMPI_fillStatusArray(int count, const MPI_Status* inStatus, int *outStatus) {
-  for (int i=0; i<count; i++) {
-    outStatus[i*3+0] = inStatus[i].MPI_SOURCE;
-    outStatus[i*3+1] = inStatus[i].MPI_TAG;
-    outStatus[i*3+2] = inStatus[i].MPI_ERROR;
-  }
+// Functions to fetch members of status.
+int gkyl_mpi_get_status_SOURCE(const MPI_Status* instat, int off) {
+  return instat[off].MPI_SOURCE;
+}
+int gkyl_mpi_get_status_TAG(const MPI_Status* instat, int off) {
+  return instat[off].MPI_TAG;
+}
+int gkyl_mpi_get_status_ERROR(const MPI_Status* instat, int off) {
+  return instat[off].MPI_ERROR;
 }
 
-int
-GkMPI_Get_count_from_array(int off, const MPI_Status *status, MPI_Datatype datatype, int *count) {
-  int err = MPI_Get_count(status+off, datatype, count);
+// Get count from a status (which may be one of several in an array of
+// statuses).
+int gkyl_mpi_get_status_count(const MPI_Status *instat, MPI_Datatype datatype, int *count, int off) {
+  int err = MPI_Get_count(instat+off, datatype, count);
   return err;
 }
+

--- a/Comm/GkylMpiFuncs.h
+++ b/Comm/GkylMpiFuncs.h
@@ -11,75 +11,100 @@
 #include <GkylMpiMacros.h>
 
 extern "C" {
-    // Sizes of various objects
-    DECL_GET_MPI_OBJ_SIZE(MPI_Status);
-    DECL_GET_MPI_OBJ_SIZE(MPI_Request);
-    DECL_GET_MPI_OBJ_PTR_SIZE(MPI_Status);
-    DECL_GET_MPI_OBJ_PTR_SIZE(MPI_Request);
-    
-    // Pre-defined objects and constants
-    DECL_GET_MPI_OBJECT(Comm, MPI_COMM_WORLD);
-    DECL_GET_MPI_OBJECT(Comm, MPI_COMM_NULL);
-    DECL_GET_MPI_OBJECT(Comm, MPI_COMM_SELF);
-    DECL_GET_MPI_OBJECT(Info, MPI_INFO_NULL);
-    
-    DECL_GET_MPI_OBJECT(Request, MPI_REQUEST_NULL);
-    DECL_GET_MPI_OBJECT_PTR(Status, MPI_STATUS_IGNORE);
-    DECL_INT_OBJECT(MPI_PROC_NULL);
+  // Sizes of various objects
+  DECL_GET_MPI_OBJ_SIZE(MPI_Status);
+  DECL_GET_MPI_OBJ_SIZE(MPI_Request);
+  DECL_GET_MPI_OBJ_PTR_SIZE(MPI_Status);
+  DECL_GET_MPI_OBJ_PTR_SIZE(MPI_Request);
+  
+  // Pre-defined objects and constants
+  DECL_GET_MPI_OBJECT(Comm, MPI_COMM_WORLD);
+  DECL_GET_MPI_OBJECT(Comm, MPI_COMM_NULL);
+  DECL_GET_MPI_OBJECT(Comm, MPI_COMM_SELF);
+  DECL_GET_MPI_OBJECT(Info, MPI_INFO_NULL);
+  
+  DECL_GET_MPI_OBJECT(Request, MPI_REQUEST_NULL);
+  DECL_GET_MPI_OBJECT_PTR(Status, MPI_STATUS_IGNORE);
+  DECL_INT_OBJECT(MPI_PROC_NULL);
 
-    // Datatypes
-    DECL_GET_MPI_OBJECT(Datatype, MPI_CHAR);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_BYTE);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_SHORT);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_INT);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_LONG);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_FLOAT);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_DOUBLE);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_UNSIGNED_CHAR);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_UNSIGNED_SHORT);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_UNSIGNED);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_UNSIGNED_LONG);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_LONG_DOUBLE);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_LONG_LONG_INT);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_FLOAT_INT);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_LONG_INT);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_DOUBLE_INT);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_SHORT_INT);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_2INT);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_LONG_DOUBLE_INT);
-    DECL_GET_MPI_OBJECT(Datatype, MPI_PACKED);
+  // Datatypes
+  DECL_GET_MPI_OBJECT(Datatype, MPI_CHAR);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_BYTE);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_SHORT);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_INT);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_LONG);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_FLOAT);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_DOUBLE);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_UNSIGNED_CHAR);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_UNSIGNED_SHORT);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_UNSIGNED);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_UNSIGNED_LONG);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_LONG_DOUBLE);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_LONG_LONG_INT);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_FLOAT_INT);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_LONG_INT);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_DOUBLE_INT);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_SHORT_INT);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_2INT);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_LONG_DOUBLE_INT);
+  DECL_GET_MPI_OBJECT(Datatype, MPI_PACKED);
 
-    // Ops
-    DECL_GET_MPI_OBJECT(Op, MPI_MAX);
-    DECL_GET_MPI_OBJECT(Op, MPI_MIN);
-    DECL_GET_MPI_OBJECT(Op, MPI_SUM);
-    DECL_GET_MPI_OBJECT(Op, MPI_PROD);
-    DECL_GET_MPI_OBJECT(Op, MPI_LAND);
-    DECL_GET_MPI_OBJECT(Op, MPI_BAND);
-    DECL_GET_MPI_OBJECT(Op, MPI_LOR);
-    DECL_GET_MPI_OBJECT(Op, MPI_BOR);
-    DECL_GET_MPI_OBJECT(Op, MPI_LXOR);
-    DECL_GET_MPI_OBJECT(Op, MPI_BXOR);
-    DECL_GET_MPI_OBJECT(Op, MPI_MINLOC);
-    DECL_GET_MPI_OBJECT(Op, MPI_MAXLOC);
+  // Ops
+  DECL_GET_MPI_OBJECT(Op, MPI_MAX);
+  DECL_GET_MPI_OBJECT(Op, MPI_MIN);
+  DECL_GET_MPI_OBJECT(Op, MPI_SUM);
+  DECL_GET_MPI_OBJECT(Op, MPI_PROD);
+  DECL_GET_MPI_OBJECT(Op, MPI_LAND);
+  DECL_GET_MPI_OBJECT(Op, MPI_BAND);
+  DECL_GET_MPI_OBJECT(Op, MPI_LOR);
+  DECL_GET_MPI_OBJECT(Op, MPI_BOR);
+  DECL_GET_MPI_OBJECT(Op, MPI_LXOR);
+  DECL_GET_MPI_OBJECT(Op, MPI_BXOR);
+  DECL_GET_MPI_OBJECT(Op, MPI_MINLOC);
+  DECL_GET_MPI_OBJECT(Op, MPI_MAXLOC);
 
-    // error codes
-    DECL_INT_OBJECT(MPI_SUCCESS);
+  // error codes
+  DECL_INT_OBJECT(MPI_SUCCESS);
 
-    // Constants
-    DECL_INT_OBJECT(MPI_COMM_TYPE_SHARED);
-    DECL_INT_OBJECT(MPI_UNDEFINED);
-    DECL_INT_OBJECT(MPI_ORDER_C);
-    DECL_INT_OBJECT(MPI_ORDER_FORTRAN);
+  // Constants
+  DECL_INT_OBJECT(MPI_COMM_TYPE_SHARED);
+  DECL_INT_OBJECT(MPI_UNDEFINED);
+  DECL_INT_OBJECT(MPI_ORDER_C);
+  DECL_INT_OBJECT(MPI_ORDER_FORTRAN);
 
-    // Some utility functions to allow accessing non-opaque MPI types
+  // Some utility functions to allow accessing non-opaque MPI types
 
-    /* Fill the outStatus with MPI_Status public data */
-    void GkMPI_fillStatus(const MPI_Status* inStatus, int *outStatus);
-    void GkMPI_fillStatusArray(int count, const MPI_Status* inStatus, int *outStatus);
+  // Gkyl structs holding status and requests.
+  typedef struct {
+    MPI_Request *req;
+  } gkyl_mpi_request;
 
-    // Get_count of a status in an array of statuses.
-    int GkMPI_Get_count_from_array(int off, const MPI_Status *status, MPI_Datatype datatype, int *count);
+  typedef struct {
+    MPI_Status *stat;
+  } gkyl_mpi_status;
+
+  typedef struct {
+    MPI_Request *req;
+    MPI_Status *stat;
+  } gkyl_mpi_request_status;
+
+  // Functions to allocate and free structs holding requests and statuses.
+  void gkyl_mpi_request_alloc(gkyl_mpi_request *rs, int num);
+  void gkyl_mpi_request_release(gkyl_mpi_request *rs);
+  void gkyl_mpi_status_alloc(gkyl_mpi_status *ss, int num);
+  void gkyl_mpi_status_release(gkyl_mpi_status *ss);
+  void gkyl_mpi_request_status_alloc(gkyl_mpi_request_status *rss, int num);
+  void gkyl_mpi_request_status_release(gkyl_mpi_request_status *rss);
+
+  // Functions to fetch members of status.
+  int gkyl_mpi_get_status_SOURCE(const MPI_Status* instat, int off);
+  int gkyl_mpi_get_status_TAG(const MPI_Status* instat, int off);
+  int gkyl_mpi_get_status_ERROR(const MPI_Status* instat, int off);
+
+  // Get count from a status (which may be one of several in an array of
+  // statuses).
+  int gkyl_mpi_get_status_count(const MPI_Status *instat, MPI_Datatype datatype, int *count, int off);
+
 }
 
 #endif // GK_MPI_FUNCS_H

--- a/Unit/test_Mpi.lua
+++ b/Unit/test_Mpi.lua
@@ -219,7 +219,7 @@ function test_6a(comm)
       Mpi.Wait(request, status)
       local count = Mpi.Get_count(status, Mpi.DOUBLE)
 
-      assert_equal(42, status.TAG, "Checking tag")
+      assert_equal(42, Mpi.getStatusTAG(status), "Checking tag")
       assert_equal(nz, count, "Checking if correct number of elements were recv-ed")
       for i = 1, nz do
 	 assert_equal(i+0.5, vOut[i], "Checking recv-ed data on rank 1")
@@ -237,7 +237,7 @@ function test_6a(comm)
       Mpi.Wait(request, status)
       local count = Mpi.Get_count(status, Mpi.DOUBLE)
 
-      assert_equal(42, status.TAG, "Checking tag")
+      assert_equal(42, Mpi.getStatusTAG(status), "Checking tag")
       assert_equal(nz, count, "Checking if correct number of elements were recv-ed")
       for i = 1, nz do
 	 assert_equal(2*(i+0.5), vOut[i], "Checking recv-ed data on rank 0")
@@ -272,7 +272,7 @@ function test_6b(comm)
       local status = Mpi.Status()
       Mpi.Wait(request, status)
       local count = Mpi.Get_count(status, Mpi.DOUBLE)
-      assert_equal(42, status.TAG, "rank 0: Checking tag")
+      assert_equal(42, Mpi.getStatusTAG(status), "rank 0: Checking tag")
       assert_equal(nz, count, "rank 0: Checking if correct number of elements were sent")
    end   
    if rank == 1 then
@@ -282,7 +282,7 @@ function test_6b(comm)
       Mpi.Wait(request, status)
       local count = Mpi.Get_count(status, Mpi.DOUBLE)
 
-      assert_equal(42, status.TAG, "rank 1: Checking tag")
+      assert_equal(42, Mpi.getStatusTAG(status), "rank 1: Checking tag")
       assert_equal(nz, count, "rank 1: Checking if correct number of elements were recv-ed")
       for i = 1, nz do
 	 assert_equal(i+0.5, vOut[i], "rank 1: Checking recv-ed data")
@@ -297,7 +297,7 @@ function test_6b(comm)
       Mpi.Wait(request, status)
       local count = Mpi.Get_count(status, Mpi.DOUBLE)
 
-      assert_equal(42, status.TAG, "rank 1: Checking tag")
+      assert_equal(42, Mpi.getStatusTAG(status), "rank 1: Checking tag")
       assert_equal(nz, count, "rank 1: Checking if correct number of elements were sent")
    end      
    if rank == 0 then
@@ -307,7 +307,7 @@ function test_6b(comm)
       Mpi.Wait(request, status)
       local count = Mpi.Get_count(status, Mpi.DOUBLE)
 
-      assert_equal(42, status.TAG, "rank 0: Checking tag")
+      assert_equal(42, Mpi.getStatusTAG(status), "rank 0: Checking tag")
       assert_equal(nz, count, "rank 0: Checking if correct number of elements were recv-ed")
       for i = 1, nz do
 	 assert_equal(2*(i+0.5), vOut[i], "rank 0: Checking recv-ed data")
@@ -340,24 +340,24 @@ function test_6c(comm)
    end
 
    -- Send message from rank 0 -> rank 1
-   local requests = Mpi.Request_vec(2)
+   local requests = Mpi.Request(2)
    if rank == 0 then
       local err
-      err = Mpi.Isend(vIn0:data(), nz0, Mpi.DOUBLE, 1, 32, comm, requests+0)
-      err = Mpi.Isend(vIn1:data(), nz1, Mpi.DOUBLE, 1, 42, comm, requests+1)
+      err = Mpi.Isend(vIn0:data(), nz0, Mpi.DOUBLE, 1, 32, comm, requests.req+0)
+      err = Mpi.Isend(vIn1:data(), nz1, Mpi.DOUBLE, 1, 42, comm, requests.req+1)
    end   
    if rank == 1 then
       local err
-      err = Mpi.Irecv(vOut0:data(), nz0, Mpi.DOUBLE, 0, 32, comm, requests+0)
-      err = Mpi.Irecv(vOut1:data(), nz1, Mpi.DOUBLE, 0, 42, comm, requests+1)
+      err = Mpi.Irecv(vOut0:data(), nz0, Mpi.DOUBLE, 0, 32, comm, requests.req+0)
+      err = Mpi.Irecv(vOut1:data(), nz1, Mpi.DOUBLE, 0, 42, comm, requests.req+1)
    end
-   local status = Mpi.Status_vec(2)
+   local status = Mpi.Status(2)
    local mpierr = Mpi.Waitall(2, requests, status)
 
-   local count = {Mpi.Get_count(status.mpiStatus, Mpi.DOUBLE, 0),
-                  Mpi.Get_count(status.mpiStatus, Mpi.DOUBLE, 1)}
-   assert_equal(32, status.TAG[1], "Checking tag")
-   assert_equal(42, status.TAG[2], "Checking tag")
+   local count = {Mpi.Get_count(status, Mpi.DOUBLE, 0),
+                  Mpi.Get_count(status, Mpi.DOUBLE, 1)}
+   assert_equal(32, Mpi.getStatusTAG(status,0), "Checking tag")
+   assert_equal(42, Mpi.getStatusTAG(status,1), "Checking tag")
    assert_equal(nz0, count[1], "Checking if correct number of elements were sent/received")
    assert_equal(nz1, count[2], "Checking if correct number of elements were sent/received")
    if rank == 1 then
@@ -372,20 +372,20 @@ function test_6c(comm)
    -- Send message from rank 1 -> rank 0
    if rank == 1 then
       local err
-      err = Mpi.Isend(vIn0:data(), nz0, Mpi.DOUBLE, 0, 32, comm, requests+0)
-      err = Mpi.Isend(vIn1:data(), nz1, Mpi.DOUBLE, 0, 42, comm, requests+1)
+      err = Mpi.Isend(vIn0:data(), nz0, Mpi.DOUBLE, 0, 32, comm, requests.req+0)
+      err = Mpi.Isend(vIn1:data(), nz1, Mpi.DOUBLE, 0, 42, comm, requests.req+1)
    end      
    if rank == 0 then
       local err
-      err = Mpi.Irecv(vOut0:data(), nz0, Mpi.DOUBLE, 1, 32, comm, requests+0)
-      err = Mpi.Irecv(vOut1:data(), nz1, Mpi.DOUBLE, 1, 42, comm, requests+1)
+      err = Mpi.Irecv(vOut0:data(), nz0, Mpi.DOUBLE, 1, 32, comm, requests.req+0)
+      err = Mpi.Irecv(vOut1:data(), nz1, Mpi.DOUBLE, 1, 42, comm, requests.req+1)
    end
    local mpierr = Mpi.Waitall(2, requests, status)
 
-   local count = {Mpi.Get_count(status.mpiStatus, Mpi.DOUBLE, 0),
-                  Mpi.Get_count(status.mpiStatus, Mpi.DOUBLE, 1)}
-   assert_equal(32, status.TAG[1], "Checking tag")
-   assert_equal(42, status.TAG[2], "Checking tag")
+   local count = {Mpi.Get_count(status, Mpi.DOUBLE, 0),
+                  Mpi.Get_count(status, Mpi.DOUBLE, 1)}
+   assert_equal(32, Mpi.getStatusTAG(status,0), "Checking tag")
+   assert_equal(42, Mpi.getStatusTAG(status,1), "Checking tag")
    assert_equal(nz0, count[1], "Checking if correct number of elements were sent/received")
    assert_equal(nz1, count[2], "Checking if correct number of elements were sent/received")
    if rank == 0 then


### PR DESCRIPTION
We now hold these in our own C structs, and in some cases use our own C functions to work with such structs. MPI and CartFieldPar unit tests pass, and I ran 2x2v p2 vm-weibel and got identical results to a serial run. Most importantly, I think this fixes the seg fault I was seeing when trying to communicate moments between parallelized species for cross-collisions (I checked, but not in this commit).

In some ways the wrapping of MPI_Request and MPI_Status is cleaner now, but we do have more functions to keep track of now. Unfortunately I couldn't find another way to make it work because of the way MPI and Lua's ffi interact.