### PR TITLE
Combine u and vtSq into a single primMoms CartField

### DIFF
--- a/Regression/gk-lbo/rt-lboRelax-1x2v-p1.lua
+++ b/Regression/gk-lbo/rt-lboRelax-1x2v-p1.lua
@@ -70,8 +70,8 @@ plasmaApp = Plasma.App {
    cflFrac     = 0.6,
    
    -- Decomposition for configuration space.
-   decompCuts = {2},            -- Cuts in each configuration direction.
-   parallelizeSpecies = true,
+   decompCuts = {1},            -- Cuts in each configuration direction.
+--   parallelizeSpecies = true,
 
    -- Boundary conditions for configuration space.
    periodicDirs = {1},          -- Periodic directions.

--- a/Updater/CrossPrimMoments.lua
+++ b/Updater/CrossPrimMoments.lua
@@ -35,33 +35,30 @@ typedef struct gkyl_prim_lbo_cross_calc gkyl_prim_lbo_cross_calc;
  * @param cbasis_rng Config-space basis functions
  * @param conf_rng Config-space range
  * @param greene Greene's factor
- * @param self_moms Moments of distribution function (Zeroth, First, and Second)
  * @param self_m Mass of the species
- * @param self_u Drift velocity of the species
- * @param self_vtsq Thermal velocity of the species
- * @param other_moms Moments of distribution function of the colliding species (Zeroth, First, and Second)
+ * @param self_moms Moments of distribution function (Zeroth, First, and Second)
+ * @param self_prim_moms Drift velocity & thermal speed squared of this species
  * @param other_m Mass of the colliding species
- * @param other_u Drift velocity of the colliding species
- * @param other_vtsq Thermal velocity of the colliding species
+ * @param other_moms Moments of distribution function (Zeroth, First, and Second)
+ * @param other_prim_moms Drift velocity & thermal speed squared of the colliding species
  * @param boundary_corrections Momentum and Energy boundary corrections
- * @param u_out Output drift velocity primitive moment array
- * @param vtsq_out Output thermal velocity primitive moment array
+ * @param prim_moms_out Output drift velocity and thermal speed squared
  */
 void gkyl_prim_lbo_cross_calc_advance(gkyl_prim_lbo_cross_calc* calc,
   struct gkyl_basis cbasis, const struct gkyl_range *conf_rng,
   const struct gkyl_array *greene,
-  double self_m, const struct gkyl_array *self_moms, const struct gkyl_array *self_u, const struct gkyl_array *self_vtsq,
-  double other_m, const struct gkyl_array *other_moms, const struct gkyl_array *other_u, const struct gkyl_array *other_vtsq,
+  double self_m, const struct gkyl_array *self_moms, const struct gkyl_array *self_prim_moms,
+  double other_m, const struct gkyl_array *other_moms, const struct gkyl_array *other_prim_moms,
   const struct gkyl_array *boundary_corrections,
-  struct gkyl_array *u_out, struct gkyl_array *vtsq_out);
+  struct gkyl_array *prim_moms_out);
 
 void gkyl_prim_lbo_cross_calc_advance_cu(gkyl_prim_lbo_cross_calc* calc,
   struct gkyl_basis cbasis, const struct gkyl_range *conf_rng,
   const struct gkyl_array *greene,
-  double self_m, const struct gkyl_array *self_moms, const struct gkyl_array *self_u, const struct gkyl_array *self_vtsq,
-  double other_m, const struct gkyl_array *other_moms, const struct gkyl_array *other_u, const struct gkyl_array *other_vtsq,
+  double self_m, const struct gkyl_array *self_moms, const struct gkyl_array *self_prim_moms,
+  double other_m, const struct gkyl_array *other_moms, const struct gkyl_array *other_prim_moms,
   const struct gkyl_array *boundary_corrections,
-  struct gkyl_array *u_out, struct gkyl_array *vtsq_out);
+  struct gkyl_array *prim_moms_out);
 
 /**
  * Delete pointer to primitive moment calculator updater.
@@ -178,18 +175,18 @@ function CrossPrimMoments:_advance(tCurr, inFld, outFld)
 
    if self._zero then
 
-      local mSelf, nuSelf   = inFld[1], inFld[2]
-      local momsSelf        = inFld[3]
-      local uSelf, vtSqSelf = inFld[4], inFld[5]
-      local bCorrsSelf      = inFld[6]
+      local mSelf, nuSelf = inFld[1], inFld[2]
+      local momsSelf      = inFld[3]
+      local primMomsSelf  = inFld[4]
+      local bCorrsSelf    = inFld[5]
 
-      local mOther, nuOther   = inFld[7], inFld[8]
-      local momsOther         = inFld[9]
-      local uOther, vtSqOther = inFld[10], inFld[11]
+      local mOther, nuOther = inFld[6], inFld[7]
+      local momsOther       = inFld[8]
+      local primMomsOther   = inFld[9]
 
-      local m0sdeltas = inFld[12]
+      local m0sdeltas = inFld[10]
 
-      local uCrossSelf, vtSqCrossSelf = outFld[1], outFld[2]
+      local primMomsCrossSelf = outFld[1]
 
       -- Compose the pre-factor:
       --   m0_s*delta_s*(1+beta)
@@ -197,9 +194,9 @@ function CrossPrimMoments:_advance(tCurr, inFld, outFld)
       m0sdeltas:scale(self._betaP1)
 
       -- Compute u and vtsq.
-      ffiC.gkyl_prim_lbo_cross_calc_advance(self._zero, self.confBasis._zero, uSelf:localRange(), m0sdeltas._zero,
-         mSelf, momsSelf._zero, uSelf._zero, vtSqSelf._zero, mOther, momsOther._zero, uOther._zero, vtSqOther._zero, 
-         bCorrsSelf._zero, uCrossSelf._zero, vtSqCrossSelf._zero)
+      ffiC.gkyl_prim_lbo_cross_calc_advance(self._zero, self.confBasis._zero, primMomsSelf:localRange(), m0sdeltas._zero,
+         mSelf, momsSelf._zero, primMomsSelf._zero, mOther, momsOther._zero, primMomsOther._zero, 
+         bCorrsSelf._zero, primMomsCrossSelf._zero)
 
       return
    end
@@ -416,18 +413,18 @@ end
 
 function CrossPrimMoments:_advanceOnDevice(tCurr, inFld, outFld)
 
-   local mSelf, nuSelf   = inFld[1], inFld[2]
-   local momsSelf        = inFld[3]
-   local uSelf, vtSqSelf = inFld[4], inFld[5]
-   local bCorrsSelf      = inFld[6]
+   local mSelf, nuSelf = inFld[1], inFld[2]
+   local momsSelf      = inFld[3]
+   local primMomsSelf  = inFld[4]
+   local bCorrsSelf    = inFld[5]
 
-   local mOther, nuOther   = inFld[7], inFld[8]
-   local momsOther         = inFld[9]
-   local uOther, vtSqOther = inFld[10], inFld[11]
+   local mOther, nuOther = inFld[6], inFld[7]
+   local momsOther       = inFld[8]
+   local primMomsOther   = inFld[9]
 
-   local m0sdeltas = inFld[12]
+   local m0sdeltas = inFld[10]
 
-   local uCrossSelf, vtSqCrossSelf = outFld[1], outFld[2]
+   local primMomsCrossSelf = outFld[1]
 
    -- Compose the pre-factor:
    --   m0_s*delta_s*(1+beta)
@@ -435,10 +432,10 @@ function CrossPrimMoments:_advanceOnDevice(tCurr, inFld, outFld)
    m0sdeltas:scale(self._betaP1)
 
    -- Compute u and vtsq.
-   ffiC.gkyl_prim_lbo_cross_calc_advance_cu(self._zero, self.confBasis._zero, uSelf:localRange(), m0sdeltas._zeroDevice,
-      mSelf, momsSelf._zeroDevice, uSelf._zeroDevice, vtSqSelf._zeroDevice,
-      mOther, momsOther._zeroDevice, uOther._zeroDevice, vtSqOther._zeroDevice, 
-      bCorrsSelf._zeroDevice, uCrossSelf._zeroDevice, vtSqCrossSelf._zeroDevice)
+   ffiC.gkyl_prim_lbo_cross_calc_advance_cu(self._zero, self.confBasis._zero, primMomsSelf:localRange(), m0sdeltas._zeroDevice,
+      mSelf, momsSelf._zeroDevice, primMomsSelf._zeroDevice,
+      mOther, momsOther._zeroDevice, primMomsOther._zeroDevice, 
+      bCorrsSelf._zeroDevice, primMomsCrossSelf._zeroDevice)
 
 end
 

--- a/Updater/SelfPrimMoments.lua
+++ b/Updater/SelfPrimMoments.lua
@@ -33,18 +33,17 @@ typedef struct gkyl_prim_lbo_calc gkyl_prim_lbo_calc;
  * @param conf_rng Config-space range
  * @param moms Moments of distribution function (Zeroth, First, and Second)
  * @param boundary_corrections Momentum and Energy boundary corrections
- * @param uout Output drift velocity primitive moment array
- * @param vtSqout Output thermal velocity primitive moment array
+ * @param prim_moms_out Output drift velocity and thermal speed squared.
  */
 void gkyl_prim_lbo_calc_advance(gkyl_prim_lbo_calc* calc, struct gkyl_basis cbasis,
   struct gkyl_range *conf_rng,
   const struct gkyl_array *moms, const struct gkyl_array *boundary_corrections,
-  struct gkyl_array *uout, struct gkyl_array *vtSqout);
+  struct gkyl_array *prim_moms_out);
 
 void gkyl_prim_lbo_calc_advance_cu(gkyl_prim_lbo_calc* calc, struct gkyl_basis cbasis,
   struct gkyl_range *conf_rng,
   const struct gkyl_array *moms, const struct gkyl_array *boundary_corrections,
-  struct gkyl_array* uout, struct gkyl_array* vtSqout);
+  struct gkyl_array* prim_moms_out);
 
 /**
  * Delete pointer to primitive moment calculator updater.
@@ -216,13 +215,13 @@ function SelfPrimMoments:_advance(tCurr, inFld, outFld)
    if self._zero_prim_calc then
 
       local moments, fIn = inFld[1], inFld[2]
-      local boundaryCorrections, u, vtsq = outFld[1], outFld[2], outFld[3]
+      local boundaryCorrections, primMoms = outFld[1], outFld[2]
 
       -- Compute boundary corrections.
-      ffiC.gkyl_mom_calc_bcorr_advance(self._zero_bcorr_calc, fIn:localRange(), u:localRange(), fIn._zero, boundaryCorrections._zero)
+      ffiC.gkyl_mom_calc_bcorr_advance(self._zero_bcorr_calc, fIn:localRange(), primMoms:localRange(), fIn._zero, boundaryCorrections._zero)
 
       -- Compute u and vtsq.
-      ffiC.gkyl_prim_lbo_calc_advance(self._zero_prim_calc, self.confBasis._zero, u:localRange(), moments._zero, boundaryCorrections._zero, u._zero, vtsq._zero)
+      ffiC.gkyl_prim_lbo_calc_advance(self._zero_prim_calc, self.confBasis._zero, primMoms:localRange(), moments._zero, boundaryCorrections._zero, primMoms._zero)
 
       return
    end
@@ -308,13 +307,13 @@ end
 function SelfPrimMoments:_advanceOnDevice(tCurr, inFld, outFld)
 
    local moments, fIn = inFld[1], inFld[2]
-   local boundaryCorrections, u, vtsq = outFld[1], outFld[2], outFld[3]
+   local boundaryCorrections, primMoms = outFld[1], outFld[2]
 
    -- Compute boundary corrections.
-   ffiC.gkyl_mom_calc_bcorr_advance_cu(self._zero_bcorr_calc, fIn:localRange(), u:localRange(), fIn._zeroDevice, boundaryCorrections._zeroDevice)
+   ffiC.gkyl_mom_calc_bcorr_advance_cu(self._zero_bcorr_calc, fIn:localRange(), primMoms:localRange(), fIn._zeroDevice, boundaryCorrections._zeroDevice)
 
    -- Compute u and vtsq.
-   ffiC.gkyl_prim_lbo_calc_advance_cu(self._zero_prim_calc, self.confBasis._zero, u:localRange(), moments._zeroDevice, boundaryCorrections._zeroDevice, u._zeroDevice, vtsq._zeroDevice)
+   ffiC.gkyl_prim_lbo_calc_advance_cu(self._zero_prim_calc, self.confBasis._zero, primMoms:localRange(), moments._zeroDevice, boundaryCorrections._zeroDevice, primMoms._zeroDevice)
 
 end
    

--- a/Updater/VlasovLBO.lua
+++ b/Updater/VlasovLBO.lua
@@ -27,26 +27,52 @@ local new, sizeof, typeof, metatype = xsys.from(ffi,
 
 ffi.cdef [[ 
 
+// Object type
 typedef struct gkyl_dg_updater_lbo_vlasov gkyl_dg_updater_lbo_vlasov;
 
-gkyl_dg_updater_lbo_vlasov*
-gkyl_dg_updater_lbo_vlasov_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis *cbasis,
-  const struct gkyl_basis *pbasis, const struct gkyl_range *conf_range, bool use_gpu);
+/**
+ * Create new updater to update lbo equations using hyper dg.
+ *
+ * @param grid Grid object
+ * @param cbasis Configuration space basis functions
+ * @param pbasis Phase-space basis function
+ * @param conf_range Config space range
+ * @return New LBO updater object
+ */
+gkyl_dg_updater_lbo_vlasov* gkyl_dg_updater_lbo_vlasov_new(const struct gkyl_rect_grid *grid,
+  const struct gkyl_basis *cbasis, const struct gkyl_basis *pbasis, const struct gkyl_range *conf_range, bool use_gpu);
 
-void
-gkyl_dg_updater_lbo_vlasov_advance(gkyl_dg_updater_lbo_vlasov *lbo,
+/**
+ * Compute RHS of DG update. The update_rng MUST be a sub-range of the
+ * range on which the array is defined. That is, it must be either the
+ * same range as the array range, or one created using the
+ * gkyl_sub_range_init method.
+ *
+ * @param lbo LBO updater object
+ * @param update_rng Range on which to compute.
+ * @param nu_sum Sum of coll freq
+ * @param nu_prim_moms Sum of coll freq*u and freq*vtsq
+ * @param fIn Input to updater
+ * @param cflrate CFL scalar rate (frequency) array (units of 1/[T])
+ * @param rhs RHS output
+ */
+void gkyl_dg_updater_lbo_vlasov_advance(gkyl_dg_updater_lbo_vlasov *lbo,
   const struct gkyl_range *update_rng,
-  const struct gkyl_array *nu_sum, const struct gkyl_array *nu_u, const struct gkyl_array *nu_vthsq,
+  const struct gkyl_array *nu_sum, const struct gkyl_array *nu_prim_moms,
   const struct gkyl_array* fIn,
   struct gkyl_array* cflrate, struct gkyl_array* rhs);
 
-void
-gkyl_dg_updater_lbo_vlasov_advance_cu(gkyl_dg_updater_lbo_vlasov *lbo,
+void gkyl_dg_updater_lbo_vlasov_advance_cu(gkyl_dg_updater_lbo_vlasov *lbo,
   const struct gkyl_range *update_rng,
-  const struct gkyl_array *nu_sum, const struct gkyl_array *nu_u, const struct gkyl_array *nu_vthsq,
+  const struct gkyl_array *nu_sum, const struct gkyl_array *nu_prim_moms,
   const struct gkyl_array* fIn,
   struct gkyl_array* cflrate, struct gkyl_array* rhs);
 
+/**
+ * Delete updater.
+ *
+ * @param lbo Updater to delete.
+ */
 void gkyl_dg_updater_lbo_vlasov_release(gkyl_dg_updater_lbo_vlasov *lbo);
 ]]
 
@@ -73,31 +99,29 @@ end
 function VlasovLBO:_advance(tCurr, inFld, outFld)
 
    local fIn = assert(inFld[1], "VlasovLBO.advance: Must pass input distf")
-   local nu_u = assert(inFld[2], "VlasovLBO.advance: Must pass nu_u")
-   local nu_vthsq = assert(inFld[3], "VlasovLBO.advance: Must pass nu_vthsq")
-   local nu_sum = assert(inFld[4], "VlasovLBO.advance: Must pass nu_sum")
+   local nu_prim_moms = assert(inFld[2], "VlasovLBO.advance: Must pass nu_prim_moms")
+   local nu_sum = assert(inFld[3], "VlasovLBO.advance: Must pass nu_sum")
  
    local fRhsOut = assert(outFld[1], "VlasovLBO.advance: Must specify an output field")
    local cflRateByCell = assert(outFld[2], "VlasovLBO.advance: Must pass cflRate field in output table")
 
    local localRange = fRhsOut:localRange()
-   ffiC.gkyl_dg_updater_lbo_vlasov_advance(self._zero, localRange, nu_sum._zero, nu_u._zero, nu_vthsq._zero, fIn._zero, cflRateByCell._zero, fRhsOut._zero)
+   ffiC.gkyl_dg_updater_lbo_vlasov_advance(self._zero, localRange, nu_sum._zero, nu_prim_moms._zero, fIn._zero, cflRateByCell._zero, fRhsOut._zero)
 
 end
 
--- advance method
+-- advanceOnDevice method
 function VlasovLBO:_advanceOnDevice(tCurr, inFld, outFld)
 
    local fIn = assert(inFld[1], "VlasovLBO.advance: Must pass input distf")
-   local nu_u = assert(inFld[2], "VlasovLBO.advance: Must pass nu_u")
-   local nu_vthsq = assert(inFld[3], "VlasovLBO.advance: Must pass nu_vthsq")
-   local nu_sum = assert(inFld[4], "VlasovLBO.advance: Must pass nu_sum")
+   local nu_prim_moms = assert(inFld[2], "VlasovLBO.advance: Must pass nu_prim_moms")
+   local nu_sum = assert(inFld[3], "VlasovLBO.advance: Must pass nu_sum")
  
    local fRhsOut = assert(outFld[1], "VlasovLBO.advance: Must specify an output field")
    local cflRateByCell = assert(outFld[2], "VlasovLBO.advance: Must pass cflRate field in output table")
 
    local localRange = fRhsOut:localRange()
-   ffiC.gkyl_dg_updater_lbo_vlasov_advance_cu(self._zero, localRange, nu_sum._zeroDevice, nu_u._zeroDevice, nu_vthsq._zeroDevice, fIn._zeroDevice, cflRateByCell._zeroDevice, fRhsOut._zeroDevice)
+   ffiC.gkyl_dg_updater_lbo_vlasov_advance_cu(self._zero, localRange, nu_sum._zeroDevice, nu_prim_moms._zeroDevice, fIn._zeroDevice, cflRateByCell._zeroDevice, fRhsOut._zeroDevice)
 
 end
 


### PR DESCRIPTION
The primitive moments u and vtSq are nearly always needed together, in cross primitive moment updaters or LBO kernels. So it makes sense to just put them into a single gkyl_array. This simplifies the Apps, doesn't change kernels much, and simplifies inter-species communication.

In some places one actually needs u OR vtSq, an for those cases I've used the gkyl_array offset methods to copy one of these to another, single-field gkyl_array.

g0 unit and regression tests pass on both CPU and GPU (although I saw a weird nvlink warning, see gkylzero's https://github.com/ammarhakim/gkylzero/commit/96dda276333efda82b0f4d77bdf4622e693f0e08). g2 vmLBO and gkLBO regression tests also pass.

This goes with gkylcas pull request 11 (https://github.com/ammarhakim/gkylcas/pull/11) and gkylzero pull request 98 (https://github.com/ammarhakim/gkylzero/pull/98).