### PR TITLE
Moments.lua: FUNC bc types

### DIFF
--- a/App/Moments/Moments.lua
+++ b/App/Moments/Moments.lua
@@ -351,13 +351,19 @@ struct gkyl_moment_species {
   void *ctx; // context for initial condition init function (and potentially other functions)
   // pointer to initialization function
   void (*init)(double t, const double *xn, double *fout, void *ctx);
-  // pointer to boundary condition functions
-  void (*bc_lower_func)(double t, int nc, const double *skin, double *  ghost, void *ctx);
-  void (*bc_upper_func)(double t, int nc, const double *skin, double *  ghost, void *ctx);
   // pointer to applied acceleration/forces function
   void (*app_accel_func)(double t, const double *xn, double *fout, void *ctx);
   // boundary conditions
   enum gkyl_species_bc_type bcx[2], bcy[2], bcz[2];
+  // pointer to boundary condition functions along x
+  void (*bcx_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcx_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  // pointer to boundary condition functions along y
+  void (*bcy_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcy_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  // pointer to boundary condition functions along z
+  void (*bcz_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcz_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
 };
 
 // Parameter for EM field
@@ -381,6 +387,15 @@ struct gkyl_moment_field {
   
   // boundary conditions
   enum gkyl_field_bc_type bcx[2], bcy[2], bcz[2];
+  // pointer to boundary condition functions along x
+  void (*bcx_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcx_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  // pointer to boundary condition functions along y
+  void (*bcy_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcy_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  // pointer to boundary condition functions along z
+  void (*bcz_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcz_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
 };
 
 // Choices of schemes to use in the fluid solver 
@@ -753,6 +768,15 @@ local function gkyl_eval_applied(func)
    end
 end
 
+local function gkyl_eval_bc(func)
+   return function(t, nc, skin, ghost, ctx)
+      local ret = { func(t, nc, skin, ctx) } -- package return into table
+      for i=1,#ret do
+         ghost[i-1] = ret[i]
+      end
+   end
+end
+
 local function gkyl_eval_mapc2p(func)
    return function(t, xn, fout, ctx)
       local xnl = ffi.new("double[10]")
@@ -837,6 +861,26 @@ local species_mt = {
          s.bcz[0], s.bcz[1] = tbl.bcz[1], tbl.bcz[2]
       end
 
+      if tbl.bcx_lower_func then
+         s.bcx_lower_func = gkyl_eval_bc(tbl.bcx_lower_func)
+      end
+      if tbl.bcy_lower_func then
+         s.bcy_lower_func = gkyl_eval_bc(tbl.bcy_lower_func)
+      end
+      if tbl.bcz_lower_func then
+         s.bcz_lower_func = gkyl_eval_bc(tbl.bcz_lower_func)
+      end
+
+      if tbl.bcx_upper_func then
+         s.bcx_upper_func = gkyl_eval_bc(tbl.bcx_upper_func)
+      end
+      if tbl.bcy_upper_func then
+         s.bcy_upper_func = gkyl_eval_bc(tbl.bcy_upper_func)
+      end
+      if tbl.bcz_upper_func then
+         s.bcz_upper_func = gkyl_eval_bc(tbl.bcz_upper_func)
+      end
+
       return s
    end,
    __index = {
@@ -845,7 +889,8 @@ local species_mt = {
       bcWall = C.GKYL_SPECIES_REFLECT,
       bcCopy = C.GKYL_SPECIES_COPY,
       bcNoSlip = C.GKYL_SPECIES_NO_SLIP,
-      bcWedge = C.GKYL_SPECIES_WEDGE
+      bcWedge = C.GKYL_SPECIES_WEDGE,
+      bcFunc = C.GKYL_SPECIES_FUNC
    }
 }
 _M.Species = ffi.metatype(species_type, species_mt)
@@ -937,6 +982,26 @@ local field_mt = {
          f.bcz[0], f.bcz[1] = tbl.bcz[1], tbl.bcz[2]
       end
 
+      if tbl.bcx_lower_func then
+         f.bcx_lower_func = gkyl_eval_bc(tbl.bcx_lower_func)
+      end
+      if tbl.bcy_lower_func then
+         f.bcy_lower_func = gkyl_eval_bc(tbl.bcy_lower_func)
+      end
+      if tbl.bcz_lower_func then
+         f.bcz_lower_func = gkyl_eval_bc(tbl.bcz_lower_func)
+      end
+
+      if tbl.bcx_upper_func then
+         f.bcx_upper_func = gkyl_eval_bc(tbl.bcx_upper_func)
+      end
+      if tbl.bcy_upper_func then
+         f.bcy_upper_func = gkyl_eval_bc(tbl.bcy_upper_func)
+      end
+      if tbl.bcz_upper_func then
+         f.bcz_upper_func = gkyl_eval_bc(tbl.bcz_upper_func)
+      end
+
       return f
    end,
    __index = {
@@ -944,7 +1009,8 @@ local field_mt = {
       bcCopy = C.GKYL_FIELD_COPY,
       bcReflect = C.GKYL_FIELD_PEC_WALL,
       bcPEC = C.GKYL_FIELD_PEC_WALL,
-      bcWedge = C.GKYL_FIELD_WEDGE
+      bcWedge = C.GKYL_FIELD_WEDGE,
+      bcFunc = C.GKYL_FIELD_FUNC
    }
 }
 _M.Field = ffi.metatype(field_type, field_mt)

--- a/App/Moments/Moments.lua
+++ b/App/Moments/Moments.lua
@@ -116,6 +116,7 @@ enum gkyl_field_bc_type {
   GKYL_FIELD_COPY = 0, // copy BCs
   GKYL_FIELD_PEC_WALL, // perfect electrical conductor (PEC) BCs
   GKYL_FIELD_WEDGE, // specialized "wedge" BCs for RZ-theta
+  GKYL_FIELD_FUNC, // Function boundary conditions
 };
 
 ]]

--- a/App/Moments/Moments.lua
+++ b/App/Moments/Moments.lua
@@ -789,6 +789,17 @@ local function gkyl_eval_mapc2p(func)
    end
 end
 
+local function gkyl_get_c_func(func, eval)
+   local entry_type = type(func)
+   if (entry_type == "function") then
+      return eval(func)
+   elseif (entry_type == "cdata") then -- TODO check c func pointer rigorously
+      return func
+   else
+      assert(false, "entry must be a lua or C function; got "..entry_type)
+   end
+end
+
 -- Species object: table structure is as follows:
 --
 -- local elc = {
@@ -863,23 +874,23 @@ local species_mt = {
       end
 
       if tbl.bcx_lower_func then
-         s.bcx_lower_func = gkyl_eval_bc(tbl.bcx_lower_func)
+         s.bcx_lower_func = gkyl_get_c_func(tbl.bcx_lower_func, gkyl_eval_bc)
       end
       if tbl.bcy_lower_func then
-         s.bcy_lower_func = gkyl_eval_bc(tbl.bcy_lower_func)
+         s.bcy_lower_func = gkyl_get_c_func(tbl.bcy_lower_func, gkyl_eval_bc)
       end
       if tbl.bcz_lower_func then
-         s.bcz_lower_func = gkyl_eval_bc(tbl.bcz_lower_func)
+         s.bcz_lower_func = gkyl_get_c_func(tbl.bcz_lower_func, gkyl_eval_bc)
       end
 
       if tbl.bcx_upper_func then
-         s.bcx_upper_func = gkyl_eval_bc(tbl.bcx_upper_func)
+         s.bcx_upper_func = gkyl_get_c_func(tbl.bcx_upper_func, gkyl_eval_bc)
       end
       if tbl.bcy_upper_func then
-         s.bcy_upper_func = gkyl_eval_bc(tbl.bcy_upper_func)
+         s.bcy_upper_func = gkyl_get_c_func(tbl.bcy_upper_func, gkyl_eval_bc)
       end
       if tbl.bcz_upper_func then
-         s.bcz_upper_func = gkyl_eval_bc(tbl.bcz_upper_func)
+         s.bcz_upper_func = gkyl_get_c_func(tbl.bcz_upper_func, gkyl_eval_bc)
       end
 
       return s
@@ -984,23 +995,23 @@ local field_mt = {
       end
 
       if tbl.bcx_lower_func then
-         f.bcx_lower_func = gkyl_eval_bc(tbl.bcx_lower_func)
+         f.bcx_lower_func = gkyl_get_c_func(tbl.bcx_lower_func, gkyl_eval_bc)
       end
       if tbl.bcy_lower_func then
-         f.bcy_lower_func = gkyl_eval_bc(tbl.bcy_lower_func)
+         f.bcy_lower_func = gkyl_get_c_func(tbl.bcy_lower_func, gkyl_eval_bc)
       end
       if tbl.bcz_lower_func then
-         f.bcz_lower_func = gkyl_eval_bc(tbl.bcz_lower_func)
+         f.bcz_lower_func = gkyl_get_c_func(tbl.bcz_lower_func, gkyl_eval_bc)
       end
 
       if tbl.bcx_upper_func then
-         f.bcx_upper_func = gkyl_eval_bc(tbl.bcx_upper_func)
+         f.bcx_upper_func = gkyl_get_c_func(tbl.bcx_upper_func, gkyl_eval_bc)
       end
       if tbl.bcy_upper_func then
-         f.bcy_upper_func = gkyl_eval_bc(tbl.bcy_upper_func)
+         f.bcy_upper_func = gkyl_get_c_func(tbl.bcy_upper_func, gkyl_eval_bc)
       end
       if tbl.bcz_upper_func then
-         f.bcz_upper_func = gkyl_eval_bc(tbl.bcz_upper_func)
+         f.bcz_upper_func = gkyl_get_c_func(tbl.bcz_upper_func, gkyl_eval_bc)
       end
 
       return f

--- a/Regression/hyper-euler/rt-euler-reservoir.lua
+++ b/Regression/hyper-euler/rt-euler-reservoir.lua
@@ -2,6 +2,14 @@
 local Moments = require("App.PlasmaOnCartGrid").Moments()
 
 gasGamma = 3.0 -- gas adiabatic constant
+
+function bc_lower_func(t, nc, skin, ctx)
+   return 1.0, 0.0, 0.0, 0.0, 1.0/(gasGamma-1)
+end
+
+function bc_upper_func(t, nc, skin, ctx)
+   return 0.125, 0.0, 0.0, 0.0, 0.1/(gasGamma-1)
+end
    
 -- create app
 eulerApp = Moments.App {
@@ -27,10 +35,10 @@ eulerApp = Moments.App {
       
       evolve = true, -- evolve species?
 
-      bcx = { Moments.Species.bcConst(1.0, 0.0, 0.0, 0.0, 1.0/(gasGamma-1)),
-	      Moments.Species.bcConst(0.125, 0.0, 0.0, 0.0, 0.1/(gasGamma-1)) },
-	      
-   },   
+      bcx = { Moments.Species.bcFunc, Moments.Species.bcFunc },
+      bcx_lower_func = bc_lower_func,
+      bcx_upper_func = bc_upper_func,
+   },
 }
 -- run application
 eulerApp:run()

--- a/Regression/hyper-euler/rt-euler-wedge.lua
+++ b/Regression/hyper-euler/rt-euler-wedge.lua
@@ -16,6 +16,12 @@ function wedge(x, y, x0, y0, angle)
    ) and true or false
 end
 
+print("rhoIn", rhoIn)
+
+function bc_lower_func(t, nc, skin, ctx)
+   return rhoIn, rhoIn*uIn, 0.0, 0.0, erIn
+end
+
 -- create app
 eulerApp = Moments.App {
    tEnd = 5*2.0/uIn, -- end time
@@ -40,9 +46,9 @@ eulerApp = Moments.App {
       evolve = true, -- evolve species?
 
       -- outer boundary conditions
-      bcx = { Moments.Species.bcConst(rhoIn, rhoIn*uIn, 0.0, 0.0, erIn),
-              Moments.Species.bcCopy },
+      bcx = { Moments.Species.bcFunc, Moments.Species.bcCopy },
       bcy = { Moments.Species.bcWall, Moments.Species.bcCopy },
+      bcx_lower_func = bc_lower_func,
 
       -- has interior (embedded) boundary conditions?
       hasSsBnd = true,


### PR DESCRIPTION
Associated g0 PR: https://github.com/ammarhakim/gkylzero/pull/134

Usage example in lua:
```lua
function bc_upper_func(t, nc, skin, ctx)
   return rhoIn, rhoIn*uIn, 0.0, 0.0, erIn
end

fluid = Moments.Species {
   -- ...
   bcx = { Moments.Species.bcCopy, Moments.Species.bcFunc},
   bcx_upper_func = bc_upper_func,
   -- ...
}
```