### PR TITLE
Use Proto for Moments app

### DIFF
--- a/App/Moments/Moments.lua
+++ b/App/Moments/Moments.lua
@@ -1031,216 +1031,214 @@ _M.Field = ffi.metatype(field_type, field_mt)
 -- App
 local App = Proto()
 
-
 App.init = function(self, tbl)
-      local vm = ffi.new("struct gkyl_moment")
+   local vm = ffi.new("struct gkyl_moment")
 
-      local species = { }
-      local field = nil
+   local species = { }
+   local field = nil
 
-      -- first determine all species in system
-      for k,v in pairs(tbl) do
-	 if ffi.istype(species_type, v) then
-	    v.name = k -- assign species name here
-	    table.insert(species, v)
-	 end
-	 if ffi.istype(field_type, v) then
-	    field = v -- only one field can be present
-	 end
+   -- first determine all species in system
+   for k,v in pairs(tbl) do
+      if ffi.istype(species_type, v) then
+         v.name = k -- assign species name here
+         table.insert(species, v)
       end
-      local num_species = #species
-
-      local name = "moment"
-      if GKYL_OUT_PREFIX then
-         -- if G0 is being run from gkyl then GKYL_OUT_PREFIX is
-         -- defined
-         name = GKYL_OUT_PREFIX
-      else
-         local s, e = string.find(arg[0], ".lua")
-         name = string.sub(arg[0], 1, s-1)
+      if ffi.istype(field_type, v) then
+         field = v -- only one field can be present
       end
-	 
-      -- set values in input struct
-      vm.name = name
-      vm.ndim = #tbl.cells
+   end
+   local num_species = #species
 
-      -- set configuration space grid data
-      for d=1, vm.ndim do
-         vm.lower[d-1] = tbl.lower[d]
-         vm.upper[d-1] = tbl.upper[d]
-         vm.cells[d-1] = tbl.cells[d]
-      end
+   local name = "moment"
+   if GKYL_OUT_PREFIX then
+      -- if G0 is being run from gkyl then GKYL_OUT_PREFIX is
+      -- defined
+      name = GKYL_OUT_PREFIX
+   else
+      local s, e = string.find(arg[0], ".lua")
+      name = string.sub(arg[0], 1, s-1)
+   end
+      
+   -- set values in input struct
+   vm.name = name
+   vm.ndim = #tbl.cells
 
-      vm.cfl_frac = 0.95 -- for consistency with C app
-      if tbl.cflFrac then
-         vm.cfl_frac = tbl.cflFrac
-      end
-
-      vm.scheme_type = C.GKYL_MOMENT_WAVE_PROP
-      if tbl.scheme_type then
-	 vm.scheme_type = moment_scheme_tags[tbl.scheme_type]
-      end
-      if tbl.schemeType then
-	 vm.scheme_type = moment_scheme_tags[tbl.schemeType]
-      end
-
-      vm.mp_recon = C.GKYL_MP_U5
-      if tbl.mp_recon then
-	 vm.mp_recon = mp_recon_tags[tbl.mp_recon]
-      end
-      if tbl.mpRecon then
-	 vm.mp_recon = mp_recon_tags[tbl.mpRecon]
-      end
-
-      vm.skip_mp_limiter = pickBool(tbl.skipMpLimiter, false)
-
-      vm.use_hybrid_flux_kep = false
-      if tbl.useHybridFluxKep then
-	 vm.use_hybrid_flux_kep = tbl.useHybridFluxKep
-      end
-
-      -- mapc2p
-      vm.c2p_ctx = nil -- no need for context
-      vm.mapc2p = nil
-      if tbl.mapc2p then
-         vm.mapc2p = gkyl_eval_mapc2p(tbl.mapc2p)
-      end
-
-      -- determine periodic BCs
-      vm.num_periodic_dir = 0
-      if tbl.periodicDirs then
-         vm.num_periodic_dir = #tbl.periodicDirs
-         for i=1, #tbl.periodicDirs do
-          vm.periodic_dirs[i-1] = tbl.periodicDirs[i]-1 -- note indexing transforms
-         end
-      end
-
-      -- determine directions to skip, if any
-      vm.num_skip_dirs = 0
-      if tbl.skip_dirs then
-         vm.num_skip_dirs = #tbl.skip_dirs
-         for i=1, #tbl.skip_dirs do
-          vm.skip_dir[i-1] = tbl.skip_dir[i]
-         end
-      end
-
-      -- set species
-      vm.num_species = #species
-      for i=1, #species do
-         vm.species[i-1] = species[i]
-      end
-
-      -- set field
-      if field then
-         vm.field = field
-      end      
-
-      -- we need to store some stuff in container struct
-      self.nspecies = num_species
-      if tbl.tStart then
-         self.t0 = tbl.tStart
-      else
-         self.t0 = 0
-      end
-      self.tend = tbl.tEnd
-      self.nframe = tbl.nFrame
-
-      -- initialize app from input struct
-      self.app = C.gkyl_moment_app_new(vm)
+   -- set configuration space grid data
+   for d=1, vm.ndim do
+      vm.lower[d-1] = tbl.lower[d]
+      vm.upper[d-1] = tbl.upper[d]
+      vm.cells[d-1] = tbl.cells[d]
    end
 
-   function App:__gc()
-      C.gkyl_moment_app_release(self.app)
+   vm.cfl_frac = 0.95 -- for consistency with C app
+   if tbl.cflFrac then
+      vm.cfl_frac = tbl.cflFrac
    end
-      App.apply_ic = function(self)
-         C.gkyl_moment_app_apply_ic(self.app, self.t0)
+
+   vm.scheme_type = C.GKYL_MOMENT_WAVE_PROP
+   if tbl.scheme_type then
+      vm.scheme_type = moment_scheme_tags[tbl.scheme_type]
+   end
+   if tbl.schemeType then
+      vm.scheme_type = moment_scheme_tags[tbl.schemeType]
+   end
+
+   vm.mp_recon = C.GKYL_MP_U5
+   if tbl.mp_recon then
+      vm.mp_recon = mp_recon_tags[tbl.mp_recon]
+   end
+   if tbl.mpRecon then
+      vm.mp_recon = mp_recon_tags[tbl.mpRecon]
+   end
+
+   vm.skip_mp_limiter = pickBool(tbl.skipMpLimiter, false)
+
+   vm.use_hybrid_flux_kep = false
+   if tbl.useHybridFluxKep then
+      vm.use_hybrid_flux_kep = tbl.useHybridFluxKep
+   end
+
+   -- mapc2p
+   vm.c2p_ctx = nil -- no need for context
+   vm.mapc2p = nil
+   if tbl.mapc2p then
+      vm.mapc2p = gkyl_eval_mapc2p(tbl.mapc2p)
+   end
+
+   -- determine periodic BCs
+   vm.num_periodic_dir = 0
+   if tbl.periodicDirs then
+      vm.num_periodic_dir = #tbl.periodicDirs
+      for i=1, #tbl.periodicDirs do
+       vm.periodic_dirs[i-1] = tbl.periodicDirs[i]-1 -- note indexing transforms
       end
-      App.writeField = function(self, tm, frame)
-         C.gkyl_moment_app_write_field(self.app, tm, frame)
+   end
+
+   -- determine directions to skip, if any
+   vm.num_skip_dirs = 0
+   if tbl.skip_dirs then
+      vm.num_skip_dirs = #tbl.skip_dirs
+      for i=1, #tbl.skip_dirs do
+       vm.skip_dir[i-1] = tbl.skip_dir[i]
       end
-      App.writeSpecies = function(self, tm, frame)
-         for i=1, self.nspecies do
-          C.gkyl_moment_app_write_species(self.app, i-1, tm, frame)
-         end
+   end
+
+   -- set species
+   vm.num_species = #species
+   for i=1, #species do
+      vm.species[i-1] = species[i]
+   end
+
+   -- set field
+   if field then
+      vm.field = field
+   end      
+
+   -- we need to store some stuff in container struct
+   self.nspecies = num_species
+   if tbl.tStart then
+      self.t0 = tbl.tStart
+   else
+      self.t0 = 0
+   end
+   self.tend = tbl.tEnd
+   self.nframe = tbl.nFrame
+
+   -- initialize app from input struct
+   self.app = C.gkyl_moment_app_new(vm)
+end
+
+function App:__gc()
+   C.gkyl_moment_app_release(self.app)
+end
+App.apply_ic = function(self)
+   C.gkyl_moment_app_apply_ic(self.app, self.t0)
+end
+App.writeField = function(self, tm, frame)
+   C.gkyl_moment_app_write_field(self.app, tm, frame)
+end
+App.writeSpecies = function(self, tm, frame)
+   for i=1, self.nspecies do
+      C.gkyl_moment_app_write_species(self.app, i-1, tm, frame)
+   end
+end
+App.write = function(self, tm, frame)
+   C.gkyl_moment_app_write(self.app, tm, frame)
+end
+App.writeStat = function(self)
+   C.gkyl_moment_app_stat_write(self.app)
+end
+App.update = function(self, dt)
+   return C.gkyl_moment_update(self.app, dt)
+end
+App.calcIntegratedMom = function(self, tcurr)
+   return C.gkyl_moment_app_calc_integrated_mom(self.app, tcurr)
+end
+App.calcFieldEnergy = function(self, tcurr)
+   return C.gkyl_moment_app_calc_field_energy(self.app, tcurr)
+end      
+App.run = function(self)
+   
+   local frame_trig = _M.TimeTrigger(self.tend/self.nframe)
+
+   -- function to write data to file
+   local function writeData(tcurr)
+      if frame_trig:checkAndBump(tcurr) then
+         self:write(tcurr, frame_trig.curr-1)
       end
-      App.write = function(self, tm, frame)
-         C.gkyl_moment_app_write(self.app, tm, frame)
+   end
+
+   local p1_trig = _M.TimeTrigger(self.tend/10)
+   -- log messages
+   local function writeLogMessage(tcurr, step, dt)
+      if p1_trig:checkAndBump(tcurr) then
+         io.write(string.format(" Step %6d %.4e. Time-step  %.6e \n", step, tcurr, dt))
       end
-      App.writeStat = function(self)
-         C.gkyl_moment_app_stat_write(self.app)
+   end
+
+   io.write(string.format("Starting GkeyllZero simulation\n"))
+   io.write(string.format("  tstart: %.6e. tend: %.6e\n", 0.0, self.tend))
+
+   local tinit0 = _M.time_now()
+   self:apply_ic()
+   io.write(string.format("  Initialization completed in %g sec\n", _M.time_now() - tinit0))
+   
+   self:calcIntegratedMom(0.0)
+   self:calcFieldEnergy(0.0)
+   writeData(0.0)
+
+   local tloop0 = _M.time_now()
+   local tcurr, tend = 0.0, self.tend
+   local dt = tend-tcurr
+   local step = 1
+   while tcurr < tend do
+      local status = self:update(dt)
+      tcurr = tcurr + status.dt_actual
+
+      if status.success == false then
+         io.write(string.format("***** Simulation failed at step %5d at time %.6e\n", step, tcurr))
+         break
       end
-      App.update = function(self, dt)
-         return C.gkyl_moment_update(self.app, dt)
-      end
-      App.calcIntegratedMom = function(self, tcurr)
-	 return C.gkyl_moment_app_calc_integrated_mom(self.app, tcurr)
-      end
-      App.calcFieldEnergy = function(self, tcurr)
-	 return C.gkyl_moment_app_calc_field_energy(self.app, tcurr)
-      end      
-      App.run = function(self)
-	 
-	 local frame_trig = _M.TimeTrigger(self.tend/self.nframe)
 
-	 -- function to write data to file
-	 local function writeData(tcurr)
-	    if frame_trig:checkAndBump(tcurr) then
-	       self:write(tcurr, frame_trig.curr-1)
-	    end
-	 end
+      self:calcIntegratedMom(tcurr)
+      self:calcFieldEnergy(tcurr)	    
 
-	 local p1_trig = _M.TimeTrigger(self.tend/10)
-	 -- log messages
-	 local function writeLogMessage(tcurr, step, dt)
-	    if p1_trig:checkAndBump(tcurr) then
-	       io.write(string.format(" Step %6d %.4e. Time-step  %.6e \n", step, tcurr, dt))
-	    end
-	 end
+      writeLogMessage(tcurr, step, status.dt_actual)
+      writeData(tcurr)
 
-	 io.write(string.format("Starting GkeyllZero simulation\n"))
-	 io.write(string.format("  tstart: %.6e. tend: %.6e\n", 0.0, self.tend))
+      dt = math.min(status.dt_suggested, (tend-tcurr)*(1+1e-6))
+      step = step + 1
+   end
 
-	 local tinit0 = _M.time_now()
-	 self:apply_ic()
-	 io.write(string.format("  Initialization completed in %g sec\n", _M.time_now() - tinit0))
-	 
-	 self:calcIntegratedMom(0.0)
-	 self:calcFieldEnergy(0.0)
-	 writeData(0.0)
+   C.gkyl_moment_app_write_integrated_mom(self.app)
+   C.gkyl_moment_app_write_field_energy(self.app)
 
-	 local tloop0 = _M.time_now()
-	 local tcurr, tend = 0.0, self.tend
-	 local dt = tend-tcurr
-	 local step = 1
-	 while tcurr < tend do
-	    local status = self:update(dt)
-	    tcurr = tcurr + status.dt_actual
-
-	    if status.success == false then
-	       io.write(string.format("***** Simulation failed at step %5d at time %.6e\n", step, tcurr))
-	       break
-	    end
-
-	    self:calcIntegratedMom(tcurr)
-	    self:calcFieldEnergy(tcurr)	    
-
-	    writeLogMessage(tcurr, step, status.dt_actual)
-	    writeData(tcurr)
-
-	    dt = math.min(status.dt_suggested, (tend-tcurr)*(1+1e-6))
-	    step = step + 1
-	 end
-
-	 C.gkyl_moment_app_write_integrated_mom(self.app)
-	 C.gkyl_moment_app_write_field_energy(self.app)
-
-	 local tloop1 = _M.time_now()
-	 
-	 io.write(string.format("Completed in %d steps (tend: %.6e). \n", step-1, tcurr))
-	 io.write(string.format("Main loop took %g secs to complete\n", tloop1-tloop0))
-	 self:writeStat()
-	 
-      end
+   local tloop1 = _M.time_now()
+   
+   io.write(string.format("Completed in %d steps (tend: %.6e). \n", step-1, tcurr))
+   io.write(string.format("Main loop took %g secs to complete\n", tloop1-tloop0))
+   self:writeStat()
+end
 
 _M.App = App
 

--- a/App/Moments/Moments.lua
+++ b/App/Moments/Moments.lua
@@ -789,6 +789,17 @@ local function gkyl_eval_mapc2p(func)
    end
 end
 
+local function gkyl_get_c_func(func, eval)
+   local entry_type = type(func)
+   if (entry_type == "function") then
+      return eval(func)
+   elseif (entry_type == "cdata") then -- TODO check c func pointer rigorously
+      return func
+   else
+      assert(false, "entry must be a lua or C function; got "..entry_type)
+   end
+end
+
 -- Species object: table structure is as follows:
 --
 -- local elc = {
@@ -863,23 +874,23 @@ local species_mt = {
       end
 
       if tbl.bcx_lower_func then
-         s.bcx_lower_func = gkyl_eval_bc(tbl.bcx_lower_func)
+         s.bcx_lower_func = gkyl_get_c_func(tbl.bcx_lower_func, gkyl_eval_bc)
       end
       if tbl.bcy_lower_func then
-         s.bcy_lower_func = gkyl_eval_bc(tbl.bcy_lower_func)
+         s.bcy_lower_func = gkyl_get_c_func(tbl.bcy_lower_func, gkyl_eval_bc)
       end
       if tbl.bcz_lower_func then
-         s.bcz_lower_func = gkyl_eval_bc(tbl.bcz_lower_func)
+         s.bcz_lower_func = gkyl_get_c_func(tbl.bcz_lower_func, gkyl_eval_bc)
       end
 
       if tbl.bcx_upper_func then
-         s.bcx_upper_func = gkyl_eval_bc(tbl.bcx_upper_func)
+         s.bcx_upper_func = gkyl_get_c_func(tbl.bcx_upper_func, gkyl_eval_bc)
       end
       if tbl.bcy_upper_func then
-         s.bcy_upper_func = gkyl_eval_bc(tbl.bcy_upper_func)
+         s.bcy_upper_func = gkyl_get_c_func(tbl.bcy_upper_func, gkyl_eval_bc)
       end
       if tbl.bcz_upper_func then
-         s.bcz_upper_func = gkyl_eval_bc(tbl.bcz_upper_func)
+         s.bcz_upper_func = gkyl_get_c_func(tbl.bcz_upper_func, gkyl_eval_bc)
       end
 
       return s
@@ -984,23 +995,23 @@ local field_mt = {
       end
 
       if tbl.bcx_lower_func then
-         f.bcx_lower_func = gkyl_eval_bc(tbl.bcx_lower_func)
+         f.bcx_lower_func = gkyl_get_c_func(tbl.bcx_lower_func, gkyl_eval_bc)
       end
       if tbl.bcy_lower_func then
-         f.bcy_lower_func = gkyl_eval_bc(tbl.bcy_lower_func)
+         f.bcy_lower_func = gkyl_get_c_func(tbl.bcy_lower_func, gkyl_eval_bc)
       end
       if tbl.bcz_lower_func then
-         f.bcz_lower_func = gkyl_eval_bc(tbl.bcz_lower_func)
+         f.bcz_lower_func = gkyl_get_c_func(tbl.bcz_lower_func, gkyl_eval_bc)
       end
 
       if tbl.bcx_upper_func then
-         f.bcx_upper_func = gkyl_eval_bc(tbl.bcx_upper_func)
+         f.bcx_upper_func = gkyl_get_c_func(tbl.bcx_upper_func, gkyl_eval_bc)
       end
       if tbl.bcy_upper_func then
-         f.bcy_upper_func = gkyl_eval_bc(tbl.bcy_upper_func)
+         f.bcy_upper_func = gkyl_get_c_func(tbl.bcy_upper_func, gkyl_eval_bc)
       end
       if tbl.bcz_upper_func then
-         f.bcz_upper_func = gkyl_eval_bc(tbl.bcz_upper_func)
+         f.bcz_upper_func = gkyl_get_c_func(tbl.bcz_upper_func, gkyl_eval_bc)
       end
 
       return f

--- a/Lib/Proto.lua
+++ b/Lib/Proto.lua
@@ -12,7 +12,7 @@ local function newmember(proto, ...)
 
    if obj.__gc then
       local prox = newproxy(true)
-      getmetatable(prox).__gc = function() obj.__gc(self, obj) end
+      getmetatable(prox).__gc = function() obj:__gc() end
       obj[prox] = true
    end
 

--- a/Lib/Proto.lua
+++ b/Lib/Proto.lua
@@ -9,7 +9,13 @@
 -- call objects's init() (ctor) method if one is provided
 local function newmember(proto, ...)
    local obj = setmetatable({}, proto)
-   
+
+   if obj.__gc then
+      local prox = newproxy(true)
+      getmetatable(prox).__gc = function() obj.__gc(self, obj) end
+      obj[prox] = true
+   end
+
    if GKYL_USE_DEVICE then
       -- when we are using CUDA we may have a initDevice method to
       -- construct things on a device


### PR DESCRIPTION
Two changes:

- Allow attaching `__gc` to the "object" returned by the `newmember` method. This object, not the "class", is the one holding the resources.
- Use `Proto`  to make Moments app
  - The first step 1a59589 does the conversion but keeps most codes unchanged in order to see the changes clearly.
  - The second step 7021cf4 properly indents the codes.
- Tested on gem challenge.

The changes to allow attaching `__gc`  is a Lua 5.1 hack (Luajit uses 5.1). Note that presently, other `g2` codes that implement `__gc` all rely on a C type (through `xsys` or `luajit` `metatype` ), but the new changes to Proto work for pure Lua tables.

In principle, this should have no impact on all codes except `Moments.lua` since `__gc` is attached only when the ``class`` carries one, and no existing `Proto` children have `__gc`.