### PR TITLE
FEM Poisson solver with variable permittivity tensor and GK's perpendicular Poisson solver

### DIFF
--- a/App/Field/GkField.lua
+++ b/App/Field/GkField.lua
@@ -1099,9 +1099,7 @@ function GkGeometry:initField(population)
           self.geo.gxx, self.geo.gxy, self.geo.gyy, self.geo.gxxJ, self.geo.gxyJ, self.geo.gyyJ})
    end
    local numB = self.basis:numBasis()
-   if GKYL_USE_GPU then self.geo.b_i:copyDeviceToHost() end
    self.geo.b_i:combineOffset(1, self.geo.b_x, 0*numB, 1, self.geo.b_y, 1*numB, 1, self.geo.b_z, 2*numB)
-   if GKYL_USE_GPU then self.geo.b_i:copyHostToDevice() end
 
    -- Compute 1/B and 1/(B^2). LBO collisions require that this is
    -- done via weak operations instead of projecting 1/B or 1/B^2.

--- a/App/Field/GkField.lua
+++ b/App/Field/GkField.lua
@@ -456,9 +456,9 @@ function GkField:createSolver(population, externalField)
          }
       else
          self.epsPoisson = createField(self.grid,self.basis,{1,1},3)
-         self.epsPoisson:combineOffset(1., gxxPoisson, 0*self.basis:numBasis(),
-                                       1., gxyPoisson, 1*self.basis:numBasis(),
-                                       1., gyyPoisson, 2*self.basis:numBasis())
+         self.epsPoisson:combineOffset(-1., gxxPoisson, 0*self.basis:numBasis(),
+                                       -1., gxyPoisson, 1*self.basis:numBasis(),
+                                       -1., gyyPoisson, 2*self.basis:numBasis())
          self.weakMultiply:advance(0., {self.lapWeightPoisson, self.epsPoisson}, {self.epsPoisson})
          self.epsPoisson:copyDeviceToHost()
          self.phiSlvr = Updater.FemPoissonPerp {

--- a/DataStruct/CartField.lua
+++ b/DataStruct/CartField.lua
@@ -905,6 +905,12 @@ local function Field_meta_ctor(elct)
       scaleByCell = function (self, factByCell)
          self._zeroForOps:scale_by_cell(factByCell._zeroForOps)
       end,
+      shiftc = function (self, val, comp)
+         self._zeroForOps:shiftc(val, comp)
+      end,
+      shiftcRange = function (self, val, comp, rng)
+         self._zeroForOps:shiftc(val, comp, rng)
+      end,
       abs = isNumberType and
          function (self)
             ffiC.gkylCartFieldAbs(self:_localLower(), self:_localShape(), self._data)

--- a/DataStruct/ZeroArray.lua
+++ b/DataStruct/ZeroArray.lua
@@ -188,6 +188,16 @@ struct gkyl_array* gkyl_array_scale(struct gkyl_array *out, double a);
 struct gkyl_array* gkyl_array_scale_by_cell(struct gkyl_array *out, const struct gkyl_array *a);
 
 /**
+ * Shift the k-th coefficient in every cell, out_k = a+out_k. Returns out.
+ *
+ * @param out Output array.
+ * @param a Factor to shift k-th coefficient by.
+ * @param k Coefficient to be shifted.
+ * @return out array.
+ */
+struct gkyl_array* gkyl_array_shiftc(struct gkyl_array *out, double a, unsigned k);
+
+/**
  * Clear out = val. Returns out.
  *
  * @param out Output array
@@ -259,6 +269,19 @@ struct gkyl_array* gkyl_array_set_offset_range(struct gkyl_array *out,
  */
 struct gkyl_array* gkyl_array_scale_range(struct gkyl_array *out,
   double a, struct gkyl_range range);
+
+/**
+ * Shift the k-th coefficient in every cell, out_k = a+out_k within
+ * a given range. Returns out.
+ *
+ * @param out Output array.
+ * @param a Factor to shift k-th coefficient by.
+ * @param k Coefficient to be shifted.
+ * @param range Range to shift coefficient k in.
+ * @return out array.
+ */
+struct gkyl_array* gkyl_array_shiftc_range(struct gkyl_array *out, double a,
+  unsigned k, struct gkyl_range range);
 
 /**
  * Copy out inp. Returns out.
@@ -440,6 +463,12 @@ local array_fn = {
    end,
    scale_by_cell = function (self, val)
       ffiC.gkyl_array_scale_by_cell(self, val)
+   end,
+   shiftc = function (self, val, comp)
+      ffiC.gkyl_array_shiftc(self, val, comp)
+   end,
+   shiftcRange = function (self, val, comp, rng)
+      ffiC.gkyl_array_shiftc_range(self, val, comp, rng)
    end,
    reduceRange = function (self, out, op, rng)
       if op == "min" then 

--- a/Regression/gk-sheath/rt-gk-sheath-3x2v-p1.lua
+++ b/Regression/gk-sheath/rt-gk-sheath-3x2v-p1.lua
@@ -221,8 +221,8 @@ plasmaApp = Plasma.App {
       isElectromagnetic = false,
       -- Dirichlet in x, periodic in y. Potential phi has homogeneous Neumann
       -- BC for the smoothing operation that enforces continuity in z.
-      bcLowerPhi  = {{T = "D", V = 0.0}, {T = "P"}, {T = "N", V = 0.0}},
-      bcUpperPhi  = {{T = "D", V = 0.0}, {T = "P"}, {T = "N", V = 0.0}},
+      bcLowerPhi  = {{T = "D", V = 0.0}, {T = "P"}},
+      bcUpperPhi  = {{T = "D", V = 0.0}, {T = "P"}},
       bcLowerApar = {{T = "D", V = 0.0}, {T = "P"}},
       bcUpperApar = {{T = "D", V = 0.0}, {T = "P"}},
    },

--- a/Unit/rtest_FemParproj.lua
+++ b/Unit/rtest_FemParproj.lua
@@ -101,8 +101,8 @@ function test_femparproj_3x(nx, ny, nz, p)
    local err = createField(grid, basis)
    err:combine(1.0, srcModal, -1.0, phiModal)
 
-   srcModal:write("phi-rough-3d.bp", 0.0)
-   phiModal:write("phi-smooth-3d.bp", 0.0)
+--   srcModal:write("phi-rough-3d.bp", 0.0)
+--   phiModal:write("phi-smooth-3d.bp", 0.0)
    --exactSolModal:write("exact-solution-1d.bp", 0.0)
    --err:write("error-1d.bp", 0.0)
 
@@ -119,13 +119,14 @@ end
 
 function test_3x_p1()
    print("--- Testing convergence of 3D FEM parallel projection with p=1 ---")
-   err1 = test_femparproj_3x(3, 3, 4, 1)
---   err2 = test_femparproj_3x(4, 4, 64, 1)
---   err3 = test_femparproj_3x(4, 4, 128, 1)
---   print("Order:", err1/err2/2.0, err2/err3/2.0)
---   assert_close(4.0, err1/err2/2.0, .05)
---   assert_close(4.0, err2/err3/2.0, .05)
---   print()
+--   err1 = test_femparproj_3x(3, 3, 4, 1)
+   err1 = test_femparproj_3x(4, 4, 32, 1)
+   err2 = test_femparproj_3x(4, 4, 64, 1)
+   err3 = test_femparproj_3x(4, 4, 128, 1)
+   print("Order:", err1/err2/2.0, err2/err3/2.0)
+   assert_close(4.0, err1/err2/2.0, .05)
+   assert_close(4.0, err2/err3/2.0, .05)
+   print()
 end
 
 local t1 = os.clock()

--- a/Unit/rtest_FemParproj.lua
+++ b/Unit/rtest_FemParproj.lua
@@ -1,0 +1,141 @@
+-- Gkyl ------------------------------------------------------------------------
+--
+-- Tests for FEM parallel Poisson solver
+--    _______     ___
+-- + 6 @ |||| # P ||| +
+--------------------------------------------------------------------------------
+
+local Unit       = require "Unit"
+local Grid       = require "Grid"
+local DataStruct = require "DataStruct"
+local Basis      = require "Basis"
+local Updater    = require "Updater"
+local Lin        = require "Lib.Linalg"
+
+local assert_equal = Unit.assert_equal
+local assert_close = Unit.assert_close
+local stats        = Unit.stats
+
+local function createGrid(lo, up, nCells, pDirs)
+   pDirs = pDirs or {}
+   local gridOut = Grid.RectCart {
+      lower = lo,  cells        = nCells,
+      upper = up,  periodicDirs = pDirs,
+   }
+   return gridOut
+end
+
+local function createBasis(dim, pOrder, bKind)
+   bKind = bKind or "Ser"
+   local basis
+   if (bKind=="Ser") then
+      basis = Basis.CartModalSerendipity { ndim = dim, polyOrder = pOrder }
+   elseif (bKind=="Tensor") then
+      basis = Basis.CartModalTensor { ndim = dim, polyOrder = pOrder }
+   else
+      assert(false,"Invalid basis")
+   end
+   return basis
+end
+
+local function createField(grid, basis, vComp)
+   vComp = vComp or 1
+   local fld = DataStruct.Field {
+      onGrid        = grid,
+      numComponents = basis:numBasis()*vComp,
+      ghost         = {1, 1},
+      metaData = {polyOrder  = basis:polyOrder(),
+                  basisType  = basis:id(),},
+   }
+   return fld
+end
+
+function test_femparproj_3x(nx, ny, nz, p)
+   print()
+   print("Testing 3D parallel FEM projection...")
+
+--   local lower = { 0.0,  0.0,  0.0}
+--   local upper = { 1.0,  1.0,  1.0}
+   local lower = {-2.0, -2.0, -.50}
+   local upper = { 2.0,  2.0,  .50}
+   local cells = {nx, ny, nz}
+   local polyOrder = p
+
+   local grid = createGrid(lower, upper, cells)
+   local basis = createBasis(grid:ndim(), polyOrder)
+   io.write("nx=",nx," ny=",ny," nz=",nz," polyOrder=", p, "\n")
+   local t1 = os.clock()
+   local poisson = Updater.FemParproj {
+      onGrid  = grid, 
+      basis   = basis,  
+      periodicParallelDir = false,
+   }
+   local t2 = os.clock()
+   local srcModal = createField(grid, basis)
+   -- initialization constants
+   local initSrcModal = Updater.ProjectOnBasis {
+      onGrid = grid,
+      basis = basis,
+      evaluate = function (t,xn)
+                    local x, y, z = xn[1], xn[2], xn[3]
+                    --local a, b = 2, -12
+                    --local c1 = 0
+                    --local c0 = -a/12 - 1/2 - b/30
+                    --return  1+a*z^2+b*z^4
+		    local mu = {0.2, 0.2}
+		    local sig = 0.3;
+		    return math.exp(-(math.pow(x-mu[1],2)+math.pow(y-mu[2],2))/(2.0*sig*sig))*math.sin(2.*math.pi*z);
+                 end
+   }
+   initSrcModal:advance(0.,{},{srcModal})
+
+   local phiModal = createField(grid, basis)
+
+   phiModal:copy(srcModal)
+   print("Smoothing...")
+   local t1 = os.clock()
+   poisson:advance(0.,{srcModal},{phiModal})
+   local t2 = os.clock()
+   io.write("3D parallel Poisson smooth took total of ", t2-t1, " s\n")
+
+   local err = createField(grid, basis)
+   err:combine(1.0, srcModal, -1.0, phiModal)
+
+   srcModal:write("phi-rough-3d.bp", 0.0)
+   phiModal:write("phi-smooth-3d.bp", 0.0)
+   --exactSolModal:write("exact-solution-1d.bp", 0.0)
+   --err:write("error-1d.bp", 0.0)
+
+   local calcInt = Updater.CartFieldIntegratedQuantCalc {
+      onGrid = grid,   numComponents = 1,
+      basis  = basis,  quantity      = "V2",
+   }
+   local dynVec = DataStruct.DynVector { numComponents = 1 }
+   calcInt:advance(0.0, {err}, {dynVec})
+   local tm, lv = dynVec:lastData()
+   io.write("Average RMS error = ", math.sqrt(lv[1]), "\n")
+   return math.sqrt(lv[1])
+end
+
+function test_3x_p1()
+   print("--- Testing convergence of 3D FEM parallel projection with p=1 ---")
+   err1 = test_femparproj_3x(3, 3, 4, 1)
+--   err2 = test_femparproj_3x(4, 4, 64, 1)
+--   err3 = test_femparproj_3x(4, 4, 128, 1)
+--   print("Order:", err1/err2/2.0, err2/err3/2.0)
+--   assert_close(4.0, err1/err2/2.0, .05)
+--   assert_close(4.0, err2/err3/2.0, .05)
+--   print()
+end
+
+local t1 = os.clock()
+test_3x_p1()
+local t2 = os.clock()
+print()
+if stats.fail > 0 then
+   print(string.format("\nPASSED %d tests", stats.pass))
+   print(string.format("**** FAILED %d tests", stats.fail))
+else
+   print(string.format("PASSED ALL %d tests!", stats.pass))
+end
+io.write("Total test time: ", t2-t1, " s\n")

--- a/Updater/Base.lua
+++ b/Updater/Base.lua
@@ -67,7 +67,7 @@ function _M:_advanceNoDeviceImpl(tCurr, inFld, outFld)
    end
    -- Also copy input fields in case they were modified.
    for _, fld in ipairs(inFld) do 
-      if type(fld)=="table" and fld._zero then fld:copyDeviceToHost() end
+      if type(fld)=="table" and fld._zero then fld:copyHostToDevice() end
    end
 end
 

--- a/Updater/FemParproj.lua
+++ b/Updater/FemParproj.lua
@@ -83,6 +83,7 @@ function FemParproj:init(tbl)
 
    self._isParPeriodic = tbl.periodicParallelDir
    assert(self._isParPeriodic ~= nil, "Updater.FemParproj: Must specify if parallel direction is periodic with 'periodicParallelDir'.")
+   self._useGPU = xsys.pickBool(tbl.useDevice, GKYL_USE_GPU or false)
 
    local weightFld  = tbl.weight
    local isWeighted = weightFld ~= nil
@@ -95,7 +96,7 @@ function FemParproj:init(tbl)
    end
 
    self._zero = ffi.gc(ffiC.gkyl_fem_parproj_new(self._grid._zero, self._basis._zero, self._isParPeriodic,
-                                                 isWeighted, weightFld._zero, GKYL_USE_GPU or 0),
+                                                 isWeighted, weightFld._zero, self._useGPU),
                        ffiC.gkyl_fem_parproj_release)
 end
 

--- a/Updater/FemPoisson.lua
+++ b/Updater/FemPoisson.lua
@@ -10,13 +10,8 @@
 local xsys = require "xsys"
 
 -- Gkyl libraries.
-local CartDecomp  = require "Lib.CartDecomp"
-local Grid        = require "Grid"
-local Lin         = require "Lib.Linalg"
 local Proto       = require "Lib.Proto"
-local Range       = require "Lib.Range"
 local UpdaterBase = require "Updater.Base"
-local DataStruct  = require "DataStruct"
 local ffi         = require "ffi"
 
 local ffiC = ffi.C

--- a/Updater/FemPoisson.lua
+++ b/Updater/FemPoisson.lua
@@ -40,27 +40,26 @@ struct gkyl_poisson_bc {
 };
 
 /**
- * Create new updater to solve the Poisson problem
- *   - nabla . (epsilon * nabla phi) = rho
- * using a FEM to ensure phi is continuous. The input is the
+ * Create new updater to solve the Helmholtz problem
+ *   - nabla . (epsilon * nabla phi) - kSq * phi = rho
+ * using a FEM to ensure phi is continuous. This solver is also
+ * used as a Poisson solver by passing a zero kSq. The input is the
  * DG field rho, which is translated to FEM. The output is the
- * DG field phi, after we've translted the FEM solution to DG.
+ * DG field phi, after we've translated the FEM solution to DG.
  * Free using gkyl_fem_poisson_release method.
- *
- * For scalar, spatially constant epsilon use gkyl_fem_poisson_consteps_new,
- * for tensor or heterogenous epsilon use gkyl_fem_poisson_vareps_new.
  *
  * @param grid Grid object
  * @param basis Basis functions of the DG field.
  * @param bcs Boundary conditions.
  * @param epsilon_const Constant scalar value of the permittivity.
  * @param epsilon_var Spatially varying permittivity tensor.
+ * @param kSq Squared wave number (factor multiplying phi in Helmholtz eq).
  * @param use_gpu boolean indicating whether to use the GPU.
  * @return New updater pointer.
  */
 gkyl_fem_poisson* gkyl_fem_poisson_new(
   const struct gkyl_rect_grid *grid, const struct gkyl_basis basis, struct gkyl_poisson_bc *bcs,
-  double epsilon_const, struct gkyl_array *epsilon_var, bool use_gpu);
+  double epsilon_const, struct gkyl_array *epsilon_var, struct gkyl_array *kSq, bool use_gpu);
 
 /**
  * Assign the right-side vector with the discontinuous (DG) source field.
@@ -94,6 +93,7 @@ function FemPoisson:init(tbl)
    self._grid   = assert(tbl.onGrid, "Updater.FemPoisson: Must specify grid to use with 'onGrid'.")
    self._basis  = assert(tbl.basis, "Updater.FemPoisson: Must specify the basis in 'basis'.")
    local eps0   = assert(tbl.epsilon_0, "Updater.FemPoisson: Must specify the permittivity of space 'epsilon_0'.")
+   local kSq    = tbl.kSq -- Wave number squared.
    self._useGPU = xsys.pickBool(tbl.useDevice, GKYL_USE_GPU or false)
 
    local ndim = self._grid:ndim()
@@ -142,8 +142,14 @@ function FemPoisson:init(tbl)
       eps0_var = self._useGPU and eps0._zeroDevice or eps0._zero
    end
 
+   local kSq_p = nil
+   if kSq then
+      assert(type(kSq) == 'table', "Updater.FemPoissonPerp: squared wave-number kSq must be a CartField.")
+      kSq_p = kSq._zero
+   end
+
    self._zero = ffi.gc(ffiC.gkyl_fem_poisson_new(self._grid._zero, self._basis._zero, bc_zero,
-                                                 eps0_const, eps0_var, self._useGPU),
+                                                 eps0_const, eps0_var, kSq_p, self._useGPU),
                        ffiC.gkyl_fem_poisson_release)
 end
 

--- a/Updater/FemPoissonPerp.lua
+++ b/Updater/FemPoissonPerp.lua
@@ -1,0 +1,145 @@
+-- Gkyl ------------------------------------------------------------------------
+--
+-- Solve the perpendicular Poisson/Helmholtz equation
+--   -nabla . (epsilon * nabla_perp phi) - kSq*phi = rho
+-- using the continuous finite element method.
+--
+--    _______     ___
+-- + 6 @ |||| # P ||| +
+--------------------------------------------------------------------------------
+-- System libraries
+local xsys = require "xsys"
+
+-- Gkyl libraries.
+local Proto       = require "Lib.Proto"
+local UpdaterBase = require "Updater.Base"
+local ffi         = require "ffi"
+
+local ffiC = ffi.C
+require "Lib.ZeroUtil"
+
+-- Declaration of gkylzero objects and functions.
+ffi.cdef [[
+// Object type
+typedef struct gkyl_fem_poisson_perp gkyl_fem_poisson_perp;
+
+/**
+ * Create new updater to solve the Helmholtz problem
+ *   - nabla . (epsilon * nabla phi) - kSq * phi = rho
+ * using a FEM to ensure phi is continuous. This solver is also
+ * used as a Poisson solver by passing a zero kSq. The input is the
+ * DG field rho, which is translated to FEM. The output is the
+ * DG field phi, after we've translated the FEM solution to DG.
+ * Free using gkyl_fem_poisson_perp_release method.
+ *
+ * @param grid Grid object
+ * @param basis Basis functions of the DG field.
+ * @param bcs Boundary conditions.
+ * @param epsilon Spatially varying permittivity tensor.
+ * @param kSq Squared wave number (factor multiplying phi in Helmholtz eq).
+ * @param use_gpu boolean indicating whether to use the GPU.
+ * @return New updater pointer.
+ */
+struct gkyl_fem_poisson_perp* gkyl_fem_poisson_perp_new(
+  const struct gkyl_rect_grid *grid, const struct gkyl_basis basis, struct gkyl_poisson_bc *bcs,
+  struct gkyl_array *epsilon, struct gkyl_array *kSq, bool use_gpu);
+
+/**
+ * Assign the right-side vector with the discontinuous (DG) source field.
+ *
+ * @param up FEM poisson updater to run.
+ * @param rhsin DG field to set as RHS source.
+ */
+void gkyl_fem_poisson_perp_set_rhs(gkyl_fem_poisson_perp* up, struct gkyl_array *rhsin);
+
+/**
+ * Solve the linear problem.
+ *
+ * @param up FEM project updater to run.
+ */
+void gkyl_fem_poisson_perp_solve(gkyl_fem_poisson_perp* up, struct gkyl_array *phiout);
+
+/**
+ * Delete updater.
+ *
+ * @param up Updater to delete.
+ */
+void gkyl_fem_poisson_perp_release(struct gkyl_fem_poisson_perp *up);
+]]
+
+-- Boundary condition updater.
+local FemPoissonPerp = Proto(UpdaterBase)
+
+function FemPoissonPerp:init(tbl)
+   FemPoissonPerp.super.init(self, tbl) -- Setup base object.
+
+   self._grid   = assert(tbl.onGrid, "Updater.FemPoissonPerp: Must specify grid to use with 'onGrid'.")
+   self._basis  = assert(tbl.basis, "Updater.FemPoissonPerp: Must specify the basis in 'basis'.")
+   local eps    = assert(tbl.epsilon, "Updater.FemPoissonPerp: Must specify the permittivity 'epsilon'.")
+   local kSq    = tbl.kSq -- Wave number squared.
+   self._useGPU = xsys.pickBool(tbl.useDevice, GKYL_USE_GPU or false)
+
+   local ndim = self._grid:ndim()
+
+   local function translateBcType(bcTypeIn)
+      -- These have to match gkyl_poisson_bc_type in gkylzero/zero/gkyl_fem_poisson_perp.h.
+      local bcKey = {GKYL_POISSON_PERIODIC  = 0,
+                     GKYL_POISSON_DIRICHLET = 1,
+                     GKYL_POISSON_NEUMANN   = 2,
+      }
+          if bcTypeIn == "P" then return bcKey["GKYL_POISSON_PERIODIC"]
+      elseif bcTypeIn == "D" then return bcKey["GKYL_POISSON_DIRICHLET"]
+      elseif bcTypeIn == "N" then return bcKey["GKYL_POISSON_NEUMANN"]
+      else assert(false, "Updater.FemPoissonPerp: boundary condition type must be specified by one of 'P', 'D', 'N'.")
+      end
+   end
+
+   local bc_zero = ffi.new("struct gkyl_poisson_bc")
+   if tbl.bcLower and tbl.bcUpper then
+      for d = 1,ndim do
+         bc_zero.lo_type[d-1] = translateBcType(tbl.bcLower[d].T)
+         bc_zero.up_type[d-1] = translateBcType(tbl.bcUpper[d].T)
+
+         if tbl.bcLower[d].T ~= "P" then
+            bc_zero.lo_value[d-1].v[0] = tbl.bcLower[d].V
+         end
+         if tbl.bcUpper[d].T ~= "P" then
+            bc_zero.up_value[d-1].v[0] = tbl.bcUpper[d].V
+         end
+      end
+   else
+      assert(false, "Updater.FemPoissonPerp: must specify 'bcLower' and 'bcUpper'.")
+   end
+
+   assert(type(eps) == 'table', "Updater.FemPoissonPerp: permittivity epsilon must be a CartField.")
+   local eps_p = eps._zero
+   local kSq_p = nil
+   if kSq then
+      assert(type(kSq) == 'table', "Updater.FemPoissonPerp: squared wave-number kSq must be a CartField.")
+      kSq_p = kSq._zero
+   end
+
+   self._zero = ffi.gc(ffiC.gkyl_fem_poisson_perp_new(self._grid._zero, self._basis._zero, bc_zero,
+                                                       eps_p, kSq_p, self._useGPU),
+                       ffiC.gkyl_fem_poisson_perp_release)
+end
+
+function FemPoissonPerp:_advance(tCurr, inFld, outFld)
+   local rhoIn = assert(inFld[1], "FemPoissonPerp.advance: Must-specify an input field")
+   local qOut  = assert(outFld[1], "FemPoissonPerp.advance: Must-specify an output field")
+
+   ffiC.gkyl_fem_poisson_perp_set_rhs(self._zero, rhoIn._zero)
+   ffiC.gkyl_fem_poisson_perp_solve(self._zero, qOut._zero)
+end
+
+function FemPoissonPerp:_advanceOnDevice(tCurr, inFld, outFld)
+   local rhoIn = assert(inFld[1], "FemPoissonPerp.advance: Must-specify an input field")
+   local qOut  = assert(outFld[1], "FemPoissonPerp.advance: Must-specify an output field")
+
+   ffiC.gkyl_fem_poisson_perp_set_rhs(self._zero, rhoIn._zeroDevice)
+   ffiC.gkyl_fem_poisson_perp_solve(self._zero, qOut._zeroDevice)
+end
+
+function FemPoissonPerp:printDevDiagnostics() end
+
+return FemPoissonPerp

--- a/Updater/FemPoissonPerp.lua
+++ b/Updater/FemPoissonPerp.lua
@@ -76,7 +76,7 @@ function FemPoissonPerp:init(tbl)
    self._grid   = assert(tbl.onGrid, "Updater.FemPoissonPerp: Must specify grid to use with 'onGrid'.")
    self._basis  = assert(tbl.basis, "Updater.FemPoissonPerp: Must specify the basis in 'basis'.")
    local eps    = assert(tbl.epsilon, "Updater.FemPoissonPerp: Must specify the permittivity 'epsilon'.")
-   local kSq    = tbl.kSq -- Wave number squared.
+   local kSq    = tbl.kSq  -- Wave number squared.
    self._useGPU = xsys.pickBool(tbl.useDevice, GKYL_USE_GPU or false)
 
    local ndim = self._grid:ndim()
@@ -112,15 +112,15 @@ function FemPoissonPerp:init(tbl)
    end
 
    assert(type(eps) == 'table', "Updater.FemPoissonPerp: permittivity epsilon must be a CartField.")
-   local eps_p = eps._zero
+   local eps_p = self._useGPU and eps._zeroDevice or eps._zero
    local kSq_p = nil
    if kSq then
       assert(type(kSq) == 'table', "Updater.FemPoissonPerp: squared wave-number kSq must be a CartField.")
-      kSq_p = kSq._zero
+      kSq_p = self._useGPU and kSq._zeroDevice or kSq._zero
    end
 
    self._zero = ffi.gc(ffiC.gkyl_fem_poisson_perp_new(self._grid._zero, self._basis._zero, bc_zero,
-                                                       eps_p, kSq_p, self._useGPU),
+                                                      eps_p, kSq_p, self._useGPU),
                        ffiC.gkyl_fem_poisson_perp_release)
 end
 

--- a/Updater/SeparateVectorComponents.lua
+++ b/Updater/SeparateVectorComponents.lua
@@ -40,16 +40,6 @@ function SeparateVectorComponents:_advance(tCurr, inFld, outFld)
 end
 
 function SeparateVectorComponents:_advanceOnDevice(tCurr, inFld, outFld)
-   -- Copy input fields from device -> host.
-   for _, fld in ipairs(inFld) do
-      if type(fld)=="table" and fld._zero then fld:copyDeviceToHost() end
-   end
-    -- Also copy output fields in case they are inputs too,
-    -- or are incremented rather than overwritten.
-   for _, fld in ipairs(outFld) do
-      if type(fld)=="table" and fld._zero then fld:copyDeviceToHost() end
-   end
-
    self:_advance(tCurr, inFld, outFld)
 end
 

--- a/Updater/init.lua
+++ b/Updater/init.lua
@@ -28,6 +28,7 @@ local FemParPoisson = require "Updater.FemParPoisson"
 local FemParproj = require "Updater.FemParproj"
 local FemPerpPoisson = require "Updater.FemPerpPoisson"
 local FemPoisson = require "Updater.FemPoisson"
+local FemPoissonPerp = require "Updater.FemPoissonPerp"
 local FiveMomentSrc = require "Updater.FiveMomentSrc"
 local FluidDG = require "Updater.FluidDG"
 local GkFemPoisson = require "Updater.GkFemPoisson"
@@ -90,6 +91,7 @@ return {
    FemParproj = FemParproj,
    FemPerpPoisson = FemPerpPoisson,
    FemPoisson = FemPoisson,
+   FemPoissonPerp = FemPoissonPerp,
    FiveMomentSrc = FiveMomentSrc,
    FluidDG = FluidDG,
    GkFemPoisson = GkFemPoisson,


### PR DESCRIPTION
This goes with PR 156 in gkylzero: https://github.com/ammarhakim/gkylzero/pull/156

Modify fem_poisson updater to solve the Poisson problem with permittivity tensor. We also added a Helmholtz term, so that the updater can actually solve
-div eps(x) grad phi - kSq(x) phi = rho
where phi is the potential and rho the charge density.

Implement fem_poisson_perp to solve the perpendicular Poisson problem for gyrokinetics:
-div eps(x) grad_perp phi - kSq(x) phi = rho
We do this in a 3D sense in each slab at one cell along z.

It's all been tested and behaves as expected, with the exception that the perp Poisson solver doesn't work when the domain is periodic (e.g. a variation in z arises when there should be none). I haven't figured out why, and will leave it for future work since that's not our main use case.