### PR TITLE
Add support for parallel vlasov-poisson + make external Vlasov force more efficient

### DIFF
--- a/App/BCs/VlasovBasic.lua
+++ b/App/BCs/VlasovBasic.lua
@@ -123,6 +123,10 @@ function VlasovBasicBC:createSolver(mySpecies, field, externalField)
    -- the fluxes through a boundary (e.g. neutral recycling).
    if self.saveFlux then
 
+      -- Part of global ghost range this rank owns.
+      self.myGlobalGhostRange = self.bcEdge=="lower" and distf:localGlobalGhostRangeIntersectLower()[self.bcDir]
+                                                      or distf:localGlobalGhostRangeIntersectUpper()[self.bcDir]
+
       -- Create reduced boundary config-space grid with 1 cell in dimension of self.bcDir.
       self:createConfBoundaryGrid(globalGhostRange, self.bcEdge=="lower" and distf:lowerGhostVec() or distf:upperGhostVec())
 
@@ -138,7 +142,8 @@ function VlasovBasicBC:createSolver(mySpecies, field, externalField)
       self.allocIntMoment = function(self, comp)
          local metaData = {charge = self.charge,  mass = self.mass,}
          local ncomp = comp or 1
-         local f = DataStruct.DynVector{numComponents = ncomp,     writeRank = self.confBoundaryGrid:commSet().writeRank,
+         local gridWriteRank = self.confBoundaryGrid:commSet().writeRank
+         local f = DataStruct.DynVector{numComponents = ncomp,     writeRank = gridWriteRank<0 and gridWriteRank or 0,
                                         metaData      = metaData,  comm      = self.confBoundaryGrid:commSet().comm,}
          return f
       end
@@ -151,10 +156,6 @@ function VlasovBasicBC:createSolver(mySpecies, field, externalField)
       end
       self.boundaryFluxRate      = allocDistf()
       self.boundaryFluxFieldPrev = allocDistf()
-
-      -- Part of global ghost range this rank owns.
-      self.myGlobalGhostRange = self.bcEdge=="lower" and distf:localGlobalGhostRangeIntersectLower()[self.bcDir]
-                                                      or distf:localGlobalGhostRangeIntersectUpper()[self.bcDir]
 
       -- The following are needed to evaluate a conf-space CartField on the confBoundaryGrid.
       self.confBoundaryField = self:allocMoment()

--- a/App/Field/MaxwellField.lua
+++ b/App/Field/MaxwellField.lua
@@ -12,6 +12,8 @@
 local AdiosCartFieldIo  = require "Io.AdiosCartFieldIo"
 local DataStruct        = require "DataStruct"
 local FieldBase         = require "App.Field.FieldBase"
+local Grid              = require "Grid"
+local DecompRegionCalc  = require "Lib.CartDecomp"
 local LinearTrigger     = require "LinearTrigger"
 local Mpi               = require "Comm.Mpi"
 local PerfMaxwell       = require "Eq.PerfMaxwell"
@@ -186,7 +188,29 @@ end
 function MaxwellField:hasEB() return true, self.hasMagField end
 function MaxwellField:setCfl(cfl) self.cfl = cfl end
 function MaxwellField:getCfl() return self.cfl end
-function MaxwellField:setGrid(grid) self.grid = grid end
+function MaxwellField:setGrid(grid)
+   self.grid = grid
+   self.ndim = self.grid:ndim()
+
+   local keepDims = {};  for i = 1, self.ndim do keepDims[i] = i end
+   local gridInfo = grid:childGrid(keepDims)
+   local GridConstructor = grid.mapc2p and Grid.MappedCart or Grid.RectCart
+
+   -- Create global grid for Poisson solver.
+   local confComm = self.grid:getMessenger():getConfComm_host()
+   local noCuts = {};  for d = 1,self.ndim do noCuts[d] = 1 end
+   local noDecomp = DecompRegionCalc.CartProd {  -- Decomp in x-y but not z.
+      cuts = noCuts,  comm = confComm,
+   }
+   self.gridGlobal = GridConstructor {
+      lower = gridInfo.lower,  world    = gridInfo.world,
+      upper = gridInfo.upper,  mappings = gridInfo.coordinateMap,
+      cells = gridInfo.cells,  mapc2p   = gridInfo.mapc2p,
+      periodicDirs  = gridInfo.periodicDirs,
+      messenger     = gridInfo.messenger,
+      decomposition = noDecomp,
+   }
+end
 
 function MaxwellField:getEpsilon0() return self.epsilon0 end
 function MaxwellField:getMu0() return self.mu0 end
@@ -235,26 +259,30 @@ function MaxwellField:esEnergy(tCurr, fldIn, outDynV)
    if self.esEnergyFirst then self.esEnergyFirst = false end
 end
 
+local function createField(grid, basis, ghostCells, ncomp, periodicSync, useDevice)
+   local metadata = basis and {polyOrder = basis:polyOrder(), basisType = basis:id()} or nil
+   local fld = DataStruct.Field {
+      onGrid   = grid,        numComponents    = ncomp,
+      metaData = metadata,    syncPeriodicDirs = periodicSync,
+      ghost    = ghostCells,  useDevice        = useDevice,
+   }
+   fld:clear(0.0)
+   return fld
+end
+
 function MaxwellField:alloc(nRkDup)
-   local nGhost = 1
    
+   local ghostNum = {1,1}
+
    self.em = {}
    if self.hasMagField then   -- Maxwell's induction equations.
       -- Allocate fields needed in RK update.
       for i = 1, nRkDup do
-         self.em[i] = DataStruct.Field {
-            onGrid        = self.grid,
-            numComponents = 8*self.basis:numBasis(),
-            ghost         = {nGhost, nGhost}
-         }
+         self.em[i] = createField(self.grid, self.basis, ghostNum, 8*self.basis:numBasis())
       end
 
       -- Array with one component per cell to store cflRate in each cell.
-      self.cflRateByCell = DataStruct.Field {
-         onGrid        = self.grid,
-         numComponents = 1,
-         ghost         = {1, 1},
-      }
+      self.cflRateByCell = createField(self.grid, self.basis, ghostNum, 1)
       self.cflRateByCell:clear(0.0)
       self.cflRatePtr  = self.cflRateByCell:get(1)
       self.cflRateIdxr = self.cflRateByCell:genIndexer()
@@ -265,11 +293,7 @@ function MaxwellField:alloc(nRkDup)
 
    else   -- Poisson equation.
       -- Electrostatic potential, phi.
-      local phiFld = DataStruct.Field {
-         onGrid        = self.grid,
-         numComponents = self.basis:numBasis(),
-         ghost         = {1, 1}
-      }
+      local phiFld = createField(self.grid, self.basis, ghostNum, self.basis:numBasis())
       for i = 1, nRkDup do self.em[i] = phiFld end
 
       -- For storing integrated energy components.
@@ -668,16 +692,12 @@ function ExternalMaxwellField:hasEB() return true, self.hasMagField end
 function ExternalMaxwellField:setGrid(grid) self.grid = grid end
 
 function ExternalMaxwellField:alloc(nField)
-   local nGhost = 1
+   local ghostNum = {1,1}
 
    -- Allocate fields needed in RK update.
    local emVecComp = 8
    if not self.hasMagField then emVecComp = 1 end  -- Electric field only.
-   self.em = DataStruct.Field {
-      onGrid        = self.grid,
-      numComponents = emVecComp*self.basis:numBasis(),
-      ghost         = {nGhost, nGhost},
-   }
+   self.em = createField(self.grid, self.basis, ghostNum, emVecComp*self.basis:numBasis())
 end
 
 function ExternalMaxwellField:createSolver(population)

--- a/Regression/vm-bodyforce/rt-neutral-bodyforce.lua
+++ b/Regression/vm-bodyforce/rt-neutral-bodyforce.lua
@@ -41,9 +41,17 @@ App = Vlasov.App {
       evolve = true,
       diagnostics = {"M0", "M1i", "M2"},   
       
+      -- Three equivalent ways of specifying this force.
       vlasovExtForceFunc = function(t, xn)
          return -5.0, 0.0, 0.0
       end,
+--      vlasovExtForceFunc = {
+--         {timeDependence = function(t) return 1. end, spatialDependence = function(xn) return -5.0, 0.0, 0.0  end},
+--      },
+--      vlasovExtForceFunc = {
+--         {timeDependence = function(t) return 1. end, spatialDependence = function(xn) return -2.0, 0.0, 0.0  end},
+--         {timeDependence = function(t) return 1. end, spatialDependence = function(xn) return -3.0, 0.0, 0.0  end},
+--      },
    },   
 
 }

--- a/Regression/vp-sheath/rt-vp-sheath02-1x1v-p2.lua
+++ b/Regression/vp-sheath/rt-vp-sheath02-1x1v-p2.lua
@@ -41,7 +41,7 @@ sim = Plasma.App {
 
    -- Decomposition for configuration space.
    decompCuts = {1},   -- Cuts in each configuration direction.
-   parallelizeSpecies = true,
+   parallelizeSpecies = false,
 
    -- Boundary conditions for configuration space.
    periodicDirs = {}, -- Periodic directions.

--- a/Updater/FemPoisson.lua
+++ b/Updater/FemPoisson.lua
@@ -13,6 +13,7 @@ local xsys = require "xsys"
 -- Gkyl libraries.
 local Proto       = require "Lib.Proto"
 local UpdaterBase = require "Updater.Base"
+local DataStruct  = require "DataStruct"
 local ffi         = require "ffi"
 
 local ffiC = ffi.C
@@ -52,15 +53,16 @@ struct gkyl_poisson_bc {
  * @param grid Grid object
  * @param basis Basis functions of the DG field.
  * @param bcs Boundary conditions.
- * @param epsilon_const Constant scalar value of the permittivity.
- * @param epsilon_var Spatially varying permittivity tensor.
+ * @param epsilon Permittivity tensor. Defined over the extended range.
  * @param kSq Squared wave number (factor multiplying phi in Helmholtz eq).
+ * @param is_epsilon_const =true if permittivity is constant in space.
  * @param use_gpu boolean indicating whether to use the GPU.
  * @return New updater pointer.
  */
-gkyl_fem_poisson* gkyl_fem_poisson_new(
-  const struct gkyl_rect_grid *grid, const struct gkyl_basis basis, struct gkyl_poisson_bc *bcs,
-  double epsilon_const, struct gkyl_array *epsilon_var, struct gkyl_array *kSq, bool use_gpu);
+struct gkyl_fem_poisson* gkyl_fem_poisson_new(
+  const struct gkyl_range *solve_range, const struct gkyl_rect_grid *grid, const struct gkyl_basis basis,
+  struct gkyl_poisson_bc *bcs, struct gkyl_array *epsilon_var, struct gkyl_array *kSq, bool is_epsilon_const,
+  bool use_gpu);
 
 /**
  * Assign the right-side vector with the discontinuous (DG) source field.
@@ -135,22 +137,34 @@ function FemPoisson:init(tbl)
       assert(false, "Updater.FemPoisson: must specify 'bcLower' and 'bcUpper'.")
    end
 
-   local eps0_const, eps0_var = 0, nil
+   local is_eps_const = nil
+   self.epsilon = nil
    if type(eps0) == 'number' then
-      eps0_const = eps0
+      is_eps_const = true
+      self.epsilon = DataStruct.Field {
+         onGrid        = self._grid,  ghost = {1,1},
+         numComponents = self._basis:numBasis(),
+         metaData      = {polyOrder = self._basis:polyOrder(), basisType = self._basis:id()},
+      }
+      self.epsilon:clear(0.)
+      self.epsilon:shiftc(eps0*(math.sqrt(2.)^ndim),0)
    elseif type(eps0) == 'table' then
       -- eps0 must be an array with the tensor permittivity.
-      eps0_var = self._useGPU and eps0._zeroDevice or eps0._zero
+      is_eps_const = false
+      self.epsilon = eps0
    end
+   local eps_p = self._useGPU and self.epsilon._zeroDevice or self.epsilon._zero
 
    local kSq_p = nil
    if kSq then
       assert(type(kSq) == 'table', "Updater.FemPoissonPerp: squared wave-number kSq must be a CartField.")
-      kSq_p = kSq._zero
+      kSq_p = self._useGPU and kSq._zeroDevice or kSq._zero
    end
 
-   self._zero = ffi.gc(ffiC.gkyl_fem_poisson_new(self._grid._zero, self._basis._zero, bc_zero,
-                                                 eps0_const, eps0_var, kSq_p, self._useGPU),
+   local localRange = self.epsilon:localRange()
+
+   self._zero = ffi.gc(ffiC.gkyl_fem_poisson_new(localRange, self._grid._zero, self._basis._zero, bc_zero,
+                                                 eps_p, kSq_p, is_eps_const, self._useGPU),
                        ffiC.gkyl_fem_poisson_release)
 end
 

--- a/Updater/wscript
+++ b/Updater/wscript
@@ -27,6 +27,13 @@ def build(bld):
     interpolateCalcData/CartFieldInterpSer1x.cpp
     interpolateCalcData/CartFieldInterpSer2x.cpp
 
+    mgPoissonCalcData/MGpoissonDGSer1x.cpp
+    mgPoissonCalcData/MGpoissonDGSer2x.cpp
+    mgPoissonCalcData/MGpoissonFEMSer1x.cpp
+    mgPoissonCalcData/MGpoissonFEMSer2x.cpp
+    mgPoissonCalcData/MGpoissonESenergySer1x.cpp
+    mgPoissonCalcData/MGpoissonESenergySer2x.cpp
+
     momentCalcData/DistFuncMomentLBOCalcSer1x1v.cpp
     momentCalcData/DistFuncMomentLBOCalcSer1x2v.cpp
     momentCalcData/DistFuncMomentLBOCalcSer1x3v.cpp
@@ -99,7 +106,7 @@ def build(bld):
 
     bld.shlib(source = sources,
 
-              includes = '. ../Cuda interpolateCalcData momentCalcData twistShiftData projectFluxOnGhostsData aSheathPotentialData', 
+              includes = '. ../Cuda interpolateCalcData mgPoissonCalcData momentCalcData twistShiftData projectFluxOnGhostsData aSheathPotentialData', 
 
               use='lib EIGEN MPI CUTOOLS gkylzero', target = 'updater', name = 'updater', vum = '1.0')
     


### PR DESCRIPTION
(corresponding gkylzero changes are in PR 201: https://github.com/ammarhakim/gkylzero/pull/201)

1. Modify FemPoisson and MaxwellField to add support for multi-MPI process Vlasov-Poisson solves. I tested with the vp-sheath reg test, using MPI decomposition along x or species, on CPUs and GPUs, and in all cases got the same result.
2. Change the handling of Vlasov external forcing so that users can specify separable forces (where time dependence is a multiplicative factor/function), or a table of separable forces that gets added. This allows us to project the spatial dependence only once, which should make it particularly efficient on GPUs.