### PR TITLE
simulation input file generator for the CSSI CI

### DIFF
--- a/Regression/mom-magnetosphere/generate-msphere3d.py
+++ b/Regression/mom-magnetosphere/generate-msphere3d.py
@@ -1,4 +1,137 @@
+import argparse
 
+parser = argparse.ArgumentParser(
+    description=(
+        "Generate gkyl input file of the 3d 10-moment simulation of Ganymede's "
+        "magnetosphere."
+    )
+)
+parser.add_argument("filename", help="name of the gkyl lua input file to be generated")
+parser.add_argument(
+    "--speed_of_light_factor",
+    default=100.0,
+    type=float,
+    help="lightSpeed = Consts.SPEED_OF_LIGHT / speed_of_light_factorx}",
+)
+parser.add_argument(
+    "--ion_to_electron_mass_ratio",
+    "--mass_ratio",
+    default=25.0,
+    type=float,
+    help="electron mass me = mi / ion_to_electron_mass_ratio",
+)
+parser.add_argument(
+    "--rho_in_amu_cm3",
+    "--rho_in",
+    default=56.0,
+    type=float,
+    help=(
+        "upstream inflow plasma density [amu/cm^3]; rho_in = {rho_in_amu_cm3} * 1e6 "
+        "* PROTON_MASS"
+    ),
+)
+parser.add_argument(
+    "--vx_in",
+    default=140e3,
+    type=float,
+    help=("upstream inflow plasma velocity, x component [m/s]"),
+)
+parser.add_argument(
+    "--vy_in",
+    default=0,
+    type=float,
+    help=("upstream inflow plasma velocity, y component [m/s]"),
+)
+parser.add_argument(
+    "--vz_in",
+    default=0,
+    type=float,
+    help=("upstream inflow plasma velocity, z component [m/s]"),
+)
+parser.add_argument(
+    "--p_in",
+    default=3.8e-9,
+    type=float,
+    help=("upstream inflow plasma pressure [Pa]"),
+)
+parser.add_argument(
+    "--Bx_in",
+    default=0,
+    type=float,
+    help=("upstream inflow B field, x component [T]"),
+)
+parser.add_argument(
+    "--By_in",
+    default=-6e-9,
+    type=float,
+    help=("upstream inflow B field, y component [T]"),
+)
+parser.add_argument(
+    "--Bz_in",
+    default=-77e-9,
+    type=float,
+    help=("upstream inflow B field, z component [T]"),
+)
+parser.add_argument(
+    "--xlo_R0",
+    default=-24,
+    type=float,
+    help=("domain bound, x direction, lower side, in units of planet/moon radius R0"),
+)
+parser.add_argument(
+    "--xup_R0",
+    default=24,
+    type=float,
+    help=("domain bound, x direction, upper side, in units of planet/moon radius R0"),
+)
+parser.add_argument(
+    "--ylo_R0",
+    default=-24,
+    type=float,
+    help=("domain bound, y direction, lower side, in units of planet/moon radius R0"),
+)
+parser.add_argument(
+    "--yup_R0",
+    default=24,
+    type=float,
+    help=("domain bound, y direction, upper side, in units of planet/moon radius R0"),
+)
+parser.add_argument(
+    "--zlo_R0",
+    default=-24,
+    type=float,
+    help=("domain bound, z direction, lower side, in units of planet/moon radius R0"),
+)
+parser.add_argument(
+    "--zup_R0",
+    default=24,
+    type=float,
+    help=("domain bound, z direction, upper side, in units of planet/moon radius R0"),
+)
+parser.add_argument(
+    "--Nx",
+    default=96,
+    type=int,
+    help=("number of cells in x direction"),
+)
+parser.add_argument(
+    "--Ny",
+    default=96,
+    type=int,
+    help=("number of cells in y direction"),
+)
+parser.add_argument(
+    "--Nz",
+    default=96,
+    type=int,
+    help=("number of cells in z direction"),
+)
+
+args = parser.parse_args()
+
+print(f"\n{args}\n")
+
+input_str = """
 -----------------------------------------------------------------
 -- Two-fluid modeling of mangetosphere-solar wind interaction. --
 -----------------------------------------------------------------
@@ -17,7 +150,7 @@ local Logger = require "Logger"
 ----------------
 local gasGamma = 5 / 3
 local mu0 = Consts.MU0
-local lightSpeed = Consts.SPEED_OF_LIGHT / 100.0
+local lightSpeed = Consts.SPEED_OF_LIGHT / {speed_of_light_factor}
 local epsilon0 = 1 / mu0 / (lightSpeed ^ 2)
 
 local R0 = 2634.1e3 -- Planet radius.
@@ -31,15 +164,15 @@ local rInnerBoundary = R0 -- Radius of the inner boundary.
 
 -- Inflow conditions.
 -- Inflow plasma density, velocity, and pressure.
-local rho_in = 56.0 * 1e6 * Consts.PROTON_MASS
-local vx_in = 140000.0
-local vy_in = 0
-local vz_in = 0
-local p_in = 3.8e-09
+local rho_in = {rho_in_amu_cm3} * 1e6 * Consts.PROTON_MASS
+local vx_in = {vx_in}
+local vy_in = {vy_in}
+local vz_in = {vz_in}
+local p_in = {p_in}
 -- Inflow magnetic field.
-local Bx_in = 0
-local By_in = -6e-09
-local Bz_in = -7.7e-08
+local Bx_in = {Bx_in}
+local By_in = {By_in}
+local Bz_in = {Bz_in}
 
 -- Mirror-dipole (mirdip) setup.
 local mirdip_rRamp1 = 2 * R0
@@ -50,7 +183,7 @@ local mirdip_xMirror = -2.578125 * R0
 -- Kinetic (non-MHD) parameters.
 local mi = 14 * Consts.PROTON_MASS  -- Ion mass.
 local di_in = 0.2 * R0  -- Ion inertial length based on inflow conditions.
-local mi__me = 25.0  -- Ion-to-electron mass ratio.
+local mi__me = {ion_to_electron_mass_ratio}  -- Ion-to-electron mass ratio.
 local pi__pe = 5  -- Ion-to-electron pressure ratio.
 local me = mi / mi__me  -- electron mass.
 local qi = mi / di_in / math.sqrt(mu0 * rho_in)  -- Ion charge.
@@ -58,14 +191,14 @@ local qe = -qi  -- Electron charge.
 local de_in = di_in * math.sqrt(me / mi)  -- Electron inertial length.
 
 -- Domain.
-local xlo, xup, Nx = -24 * R0, 24 * R0, 96
-local ylo, yup, Ny = -24 * R0, 24 * R0, 96
-local zlo, zup, Nz = -24 * R0, 24 * R0, 96
+local xlo, xup, Nx = {xlo_R0} * R0, {xup_R0} * R0, {Nx}
+local ylo, yup, Ny = {ylo_R0} * R0, {yup_R0} * R0, {Ny}
+local zlo, zup, Nz = {zlo_R0} * R0, {zup_R0} * R0, {Nz}
 -- Grid.
-local lower = {xlo, ylo, zlo}
-local upper = {xup, yup, zup}
-local cells = {Nx, Ny, Nz}
-local decompCuts = nil  -- {nProcessorsX, nProcessosY, nProcessorsZ}
+local lower = {{xlo, ylo, zlo}}
+local upper = {{xup, yup, zup}}
+local cells = {{Nx, Ny, Nz}}
+local decompCuts = nil  -- {{nProcessorsX, nProcessosY, nProcessorsZ}}
 local useNonUniformGrid = true
 -- Using two tanh functions to rampd down and up the grid sizes (U-shape).
 -- xl, wxl: Floor and transition-layer width of the left tanh (ramping down dx.)
@@ -125,8 +258,8 @@ local vA_in = B_in / math.sqrt(mu0 * rho_in)
 local pmag_in = B_in ^ 2 / 2 / mu0
 local beta_in = p_in / pmag_in
 
-local logger = Logger {logToFile = True}
-local log = function(...) logger(string.format(...).."\n") end
+local logger = Logger {{logToFile = True}}
+local log = function(...) logger(string.format(...).."\\n") end
 
 log("%30s = %g", "lightSpeed [km/s]", lightSpeed / 1e3)
 log("%30s = %g, %g, %g", "Dipole strength [nT]", Dx / R0 ^ 3 / 1e-9,
@@ -245,7 +378,7 @@ local function initElc(t, xc)
    local vx, vy, vz = initV(x, y, z)
    local p = initP(x, y, z) / (1 + pi__pe)
 
-   local q = {}
+   local q = {{}}
    rho_v_p_to_10m(q, rho, vx, vy, vz, p)
 
    return unpack(q)
@@ -258,7 +391,7 @@ local function initIon(t, xc)
    local vx, vy, vz = initV(x, y, z)
    local p = initP(x, y, z) * pi__pe / (1 + pi__pe)
 
-   local q = {}
+   local q = {{}}
    rho_v_p_to_10m(q, rho, vx, vy, vz, p)
 
    return unpack(q)
@@ -336,13 +469,13 @@ if useNonUniformGrid then
    --    grid size on the computational grid.
    local get_comput2phys = function(xlo, Lx, Nx, _x2dx)
       -- Node-center computational coordinates.
-      local xnComput = {0}
+      local xnComput = {{0}}
       for i = 2, Nx + 1 do
          xnComput[i] = xnComput[i - 1] + _x2dx((i - 0.5) / Nx)
       end
 
       -- Node-center physical coordinates.
-      local xnPhys = {}
+      local xnPhys = {{}}
       for i = 1, Nx + 1 do
          xnPhys[i] = xlo + xnComput[i] * Lx / xnComput[Nx + 1]
       end
@@ -356,12 +489,12 @@ if useNonUniformGrid then
       end
    end
 
-   coordinateMap = {
+   coordinateMap = {{
       get_comput2phys(xlo, Lx, Nx, _x2dx), get_comput2phys(ylo, Ly, Ny, _y2dy),
       get_comput2phys(zlo, Lz, Nz, _z2dz)
-   }
-   lower = {0, 0, 0}
-   upper = {1, 1, 1}
+   }}
+   lower = {{0, 0, 0}}
+   upper = {{1, 1, 1}}
 end
 
 -------------------------
@@ -376,7 +509,7 @@ local bcInflow_ion = TenMoment.bcConst(rhoi_in, rhovxi_in, rhovyi_in, rhovzi_in,
                                        Pxxi_in, Pxyi_in, Pxzi_in, Pyyi_in,
                                        Pyzi_in, Pzzi_in)
 
-local bcInflow_field = {
+local bcInflow_field = {{
    function(dir, tm, idxSkin, qSkin, qGhost, xcGhost, xcSkin)
       qGhost[1] = Ex_in
       qGhost[2] = Ey_in
@@ -393,22 +526,22 @@ local bcInflow_field = {
       qGhost[7] = qSkin[7]
       qGhost[8] = qSkin[8]
    end
-}
+}}
 
 -- Boundary conditions applied at the embedded inner boundary.
-local bcInner_elc = {
+local bcInner_elc = {{
    function(dir, tm, idxSkin, qSkin, qGhost, xcGhost, xcSkin)
       rho_v_p_to_10m(qGhost, rhoe_in, 0, 0, 0, pe_in)
    end
-}
+}}
 
-local bcInner_ion = {
+local bcInner_ion = {{
    function(dir, tm, idxSkin, qSkin, qGhost, xcGhost, xcSkin)
       rho_v_p_to_10m(qGhost, rhoi_in, 0, 0, 0, pi_in)
    end
-}
+}}
 
-local bcInner_field = {
+local bcInner_field = {{
    function(dir, tm, idxSkin, qSkin, qGhost, xcGhost, xcSkin)
       qGhost[1] = 0
       qGhost[2] = 0
@@ -421,12 +554,12 @@ local bcInner_field = {
       qGhost[7] = qSkin[7]
       qGhost[8] = qSkin[8]
    end
-}
+}}
 
 ------------------
 -- APP CREATION --
 ------------------
-local momentApp = Moments.App {
+local momentApp = Moments.App {{
    logToFile = true,
 
    tEnd = tEnd,
@@ -441,70 +574,76 @@ local momentApp = Moments.App {
    suggestedDt = suggestedDt,
    maximumDt = maximumDt,
 
-   elc = Moments.Species {
+   elc = Moments.Species {{
       charge = qe,
       mass = me,
-      equation = TenMoment {},
-      equationInv = TenMoment {numericalFlux = "lax"},
+      equation = TenMoment {{}},
+      equationInv = TenMoment {{numericalFlux = "lax"}},
       limiter = limiter,
       init = initElc,
-      bcx = {bcInflow_elc, Moments.Species.bcCopy},
-      bcy = {Moments.Species.bcCopy, Moments.Species.bcCopy},
-      bcz = {Moments.Species.bcCopy, Moments.Species.bcCopy},
+      bcx = {{bcInflow_elc, Moments.Species.bcCopy}},
+      bcy = {{Moments.Species.bcCopy, Moments.Species.bcCopy}},
+      bcz = {{Moments.Species.bcCopy, Moments.Species.bcCopy}},
       hasSsBnd = true,
       inOutFunc = inOutFunc,
-      ssBc = {bcInner_elc}
-   },
+      ssBc = {{bcInner_elc}}
+   }},
 
-   ion = Moments.Species {
+   ion = Moments.Species {{
       charge = qi,
       mass = mi,
-      equation = TenMoment {},
-      equationInv = TenMoment {numericalFlux = "lax"},
+      equation = TenMoment {{}},
+      equationInv = TenMoment {{numericalFlux = "lax"}},
       limiter = limiter,
       init = initIon,
-      bcx = {bcInflow_ion, Moments.Species.bcCopy},
-      bcy = {Moments.Species.bcCopy, Moments.Species.bcCopy},
-      bcz = {Moments.Species.bcCopy, Moments.Species.bcCopy},
+      bcx = {{bcInflow_ion, Moments.Species.bcCopy}},
+      bcy = {{Moments.Species.bcCopy, Moments.Species.bcCopy}},
+      bcz = {{Moments.Species.bcCopy, Moments.Species.bcCopy}},
       hasSsBnd = true,
       inOutFunc = inOutFunc,
-      ssBc = {bcInner_ion}
-   },
+      ssBc = {{bcInner_ion}}
+   }},
 
-   field = Moments.Field {
+   field = Moments.Field {{
       epsilon0 = epsilon0,
       mu0 = mu0,
       limiter = limiter,
       init = initField,
-      bcx = {bcInflow_field, Moments.Field.bcCopy},
-      bcy = {Moments.Field.bcCopy, Moments.Field.bcCopy},
-      bcz = {Moments.Field.bcCopy, Moments.Field.bcCopy},
+      bcx = {{bcInflow_field, Moments.Field.bcCopy}},
+      bcy = {{Moments.Field.bcCopy, Moments.Field.bcCopy}},
+      bcz = {{Moments.Field.bcCopy, Moments.Field.bcCopy}},
       hasSsBnd = true,
       inOutFunc = inOutFunc,
-      ssBc = {bcInner_field}
-   },
+      ssBc = {{bcInner_field}}
+   }},
 
-   emSource = Moments.CollisionlessEmSource {
-      species = {"elc", "ion"},
+   emSource = Moments.CollisionlessEmSource {{
+      species = {{"elc", "ion"}},
       timeStepper = "direct",
       hasStaticField = true,
       staticEmFunction = staticEmFunction
-   },
+   }},
 
-   elc10mRelax = Moments.TenMomentRelaxSource {
-      species = {"elc"},
+   elc10mRelax = Moments.TenMomentRelaxSource {{
+      species = {{"elc"}},
       timeStepper = "explicit",
       k = 1/de_in,
-   },
+   }},
 
-   ion10mRelax = Moments.TenMomentRelaxSource {
-      species = {"ion"},
+   ion10mRelax = Moments.TenMomentRelaxSource {{
+      species = {{"ion"}},
       timeStepper = "explicit",
       k = 1/de_in,
-   },
-}
+   }},
+}}
 
 ---------
 -- RUN --
 ---------
 momentApp:run()
+""".format(
+    **vars(args)
+)
+
+with open(args.filename, "w") as script_file:
+    script_file.write(input_str)

--- a/Regression/mom-magnetosphere/generate-msphere3d.py
+++ b/Regression/mom-magnetosphere/generate-msphere3d.py
@@ -126,8 +126,25 @@ parser.add_argument(
     type=int,
     help=("number of cells in z direction"),
 )
+parser.add_argument(
+    "--decompCuts",
+    "--nprocs",
+    default=None,
+    type=int,
+    nargs=3,
+    metavar="NPROCS",
+    help=("number of processors in x, y, and z directions"),
+)
+
 
 args = parser.parse_args()
+
+if args.decompCuts is None:
+    args.decompCuts = "nil"
+elif isinstance(args.decompCuts, list):
+    args.decompCuts = ", ".join([str(c) for c in args.decompCuts])
+else:
+    raise ValueError(f"can't process nprocs (decompCuts) {args.decompCuts}")
 
 print(f"\n{args}\n")
 
@@ -198,7 +215,7 @@ local zlo, zup, Nz = {zlo_R0} * R0, {zup_R0} * R0, {Nz}
 local lower = {{xlo, ylo, zlo}}
 local upper = {{xup, yup, zup}}
 local cells = {{Nx, Ny, Nz}}
-local decompCuts = nil  -- {{nProcessorsX, nProcessosY, nProcessorsZ}}
+local decompCuts = {decompCuts}  -- {{nProcessorsX, nProcessosY, nProcessorsZ}}
 local useNonUniformGrid = true
 -- Using two tanh functions to rampd down and up the grid sizes (U-shape).
 -- xl, wxl: Floor and transition-layer width of the left tanh (ramping down dx.)

--- a/Regression/mom-magnetosphere/generate-msphere3d.py
+++ b/Regression/mom-magnetosphere/generate-msphere3d.py
@@ -9,6 +9,8 @@ parser = argparse.ArgumentParser(
 parser.add_argument("filename", help="name of the gkyl lua input file to be generated")
 parser.add_argument(
     "--speed_of_light_factor",
+    "--speed_of_light",
+    "--c",
     default=100.0,
     type=float,
     help="lightSpeed = Consts.SPEED_OF_LIGHT / speed_of_light_factorx}",
@@ -129,6 +131,7 @@ parser.add_argument(
 parser.add_argument(
     "--decompCuts",
     "--nprocs",
+    "--nProcs",
     default=None,
     type=int,
     nargs=3,

--- a/Regression/mom-magnetosphere/generate-msphere3d.py
+++ b/Regression/mom-magnetosphere/generate-msphere3d.py
@@ -215,7 +215,7 @@ local zlo, zup, Nz = {zlo_R0} * R0, {zup_R0} * R0, {Nz}
 local lower = {{xlo, ylo, zlo}}
 local upper = {{xup, yup, zup}}
 local cells = {{Nx, Ny, Nz}}
-local decompCuts = {decompCuts}  -- {{nProcessorsX, nProcessosY, nProcessorsZ}}
+local decompCuts = {{{decompCuts}}}  -- {{nProcessorsX, nProcessosY, nProcessorsZ}}
 local useNonUniformGrid = true
 -- Using two tanh functions to rampd down and up the grid sizes (U-shape).
 -- xl, wxl: Floor and transition-layer width of the left tanh (ramping down dx.)

--- a/Regression/mom-two-stream/generate-rt-two-stream-5m.py
+++ b/Regression/mom-two-stream/generate-rt-two-stream-5m.py
@@ -1,0 +1,217 @@
+import argparse
+
+parser = argparse.ArgumentParser(description="Generate gkyl input file.")
+parser.add_argument("filename", help="name of the gkyl lua input file to be generated")
+parser.add_argument(
+    "--vDrift__vTe",
+    default=5.0,
+    type=float,
+    help="drift velocity / thermal velocity",
+)
+parser.add_argument(
+    "--kx_de",
+    default=0.1,
+    type=float,
+    help="wavenumber * Debye length",
+)
+parser.add_argument(
+    "--pert",
+    default=1e-3,
+    type=float,
+    help="perturbation magnitude to the uniform background density",
+)
+parser.add_argument(
+    "--tEnd_wpe",
+    default=40.0,
+    type=float,
+    help="simulation time * plasma frequency",
+)
+parser.add_argument(
+    "--nFrame",
+    default=10,
+    type=int,
+    help="number of output frames excluding the initial condition",
+)
+parser.add_argument(
+    "--Nx",
+    default=128,
+    type=int,
+    help="number of cells for discretization",
+)
+parser.add_argument(
+    "--nProcs",
+    default=1,
+    type=int,
+    help="number of processors for parallel computing",
+)
+args = parser.parse_args()
+
+input_str = """
+-- 1d 5-moment simulation of two-stream instability with two counter-streaming electron
+-- species, with an immobile ion species (that is not evolved).
+--
+-- 1. Note that though the problem is essentially electrostatic, i.e., without any
+-- magnetic fluctuations expected to develop, the model being used here is
+-- electromagnetic. In this case, magnetic fluctuations will be no more than the machine
+-- error. It is critical to note that using an EM model to mimic a ES problem does not
+-- always work. It works in this case because it is 1d and there is no net current.
+--
+-- 2. This input deck allows the user to specify the wavenumber, and then the domain
+-- length is set to fit exactly one wavelength.
+--
+-- 3. One educational study is to vary the value of vDrift and / or the wavenumber to
+-- compare the growth rates.
+
+------------------------
+-- SETTING PARAMETERS --
+------------------------
+
+-- Parameters that should not be changed
+gasGamma = 3.0 -- adiabatic gas gamma, typically (f+3) / f where if is degree of freedom
+-- Light speed is needed for any EM simulation. A large value is chosen to minimize the
+-- impact of the EM effects over ES effects.
+lightSpeed = 100.0
+epsilon0 = 1.0 -- vacuum permittivity
+
+-- Properties of the streaming species (assumed to beelectron). Note that the following
+-- values lead to Debye length and plasma frequency of numerical values 1.
+vTe = 1.0 -- thermal velocity
+n = 1.0 -- background number density
+me = 1.0 -- mass
+qe = -1.0 -- charge
+
+-- Physical parameters intended to be changed for parameter scanning
+vDrift__vTe = {vDrift__vTe} -- drift velocity / thermal velocity
+kx_de = {kx_de} -- wavenumber * Debye length
+pert = {pert} -- perturbation magnitude to the uniform background density
+
+-- Computational paremters
+nProcs = {nProcs} -- number of processors for parallel computing
+tEnd_wpe = {tEnd_wpe} -- simulation time * plasma frequency
+nFrame = {nFrame} -- number of output frames excluding the initial condition
+Nx = {Nx} -- number of cells for discretization
+
+-- Derived parameters
+mu0 = 1 / lightSpeed^2 / epsilon0 -- vacuum permeability
+vDrift = vDrift__vTe * vTe -- drift velocity
+T = me * vTe^2 -- temperature
+de = math.sqrt(epsilon0 / qe^2 * T / n) -- Debye length
+kx = kx_de / de -- wavenumber
+Lx = math.pi / kx -- domain length
+wpe = math.sqrt(n * qe^2 / me / epsilon0) -- plasma frequency
+tEnd = tEnd_wpe / wpe
+
+-----------------------------------
+-- SHOWING SIMULATION PARAMETERS --
+-----------------------------------
+
+local Logger = require "Logger"
+local logger = Logger {{logToFile = True}}
+local log = function(...) logger(string.format(...).."\\n") end
+
+log("")
+log("%30s = %g, %g", "Debye length, plasma frequency", de, wpe)
+log("%30s = %g, %g", "vDrift / vTe, vDrift", vDrift / vTe, vDrift)
+log("%30s = %g, %g", "kx * Debye length", kx * de, kx)
+log("%30s = %g, %g", "tEnd * Plasma frequency", tEnd * wpe, tEnd)
+log("%30s = %g", "perturbation level", pert)
+log("%30s = %g", "Nx", Nx)
+log("%30s = %g", "nFrame", nFrame)
+log("%30s = %g", "tEnd / nFrame", tEnd / nFrame)
+log("%30s = %g", "lightSpeed / vTe", lightSpeed / vTe)
+log("")
+
+----------------------------------------
+-- CREATING AND RUNNING THE GKYL APPS --
+----------------------------------------
+
+local Moments = require("App.PlasmaOnCartGrid").Moments()
+local Euler = require "Eq.Euler"
+
+app = Moments.App {{
+
+   tEnd = tEnd, -- end of simulation time
+   nFrame = nFrame, -- number of output frames
+   lower = {{0}}, -- lower limit of domain
+   upper = {{Lx}}, -- upper limit of domain
+   cells = {{Nx}}, -- number of cells to discretize the domain
+   decompCuts = {{nProcs}}, -- domain decomposition
+   periodicDirs = {{1}}, -- directions with periodic boundary conditions; 1:x, 2:y, 3:z
+   timeStepper = "fvDimSplit", -- dimensional-splitting finite-volume algorithm
+   logToFile = true,
+
+   -- right-going species
+   e1 = Moments.Species {{
+      charge = qe,
+      mass = me,
+      equation = Euler {{ gasGamma = gasGamma }},
+      equationInv = Euler {{ gasGamma = gasGamma, numericalFlux = "lax" }},
+      init = function(t, xn)
+         local x = xn[1]
+         
+         local rho = n * me
+         local vx = vDrift
+         local vy = 0
+         local vz = 0
+         local p = n * T * (1 + pert * math.cos(kx * x))
+         local e = p / (gasGamma-1) + 0.5 * rho * (vx*vx + vy*vy + vz*vz)
+
+         return rho, rho*vx, rho*vy, rho*vz, e
+      end,
+      evolve = true,
+   }},
+
+   -- left-going species
+   e2 = Moments.Species {{
+      charge = qe,
+      mass = me,
+      equation = Euler {{ gasGamma = gasGamma }},
+      equationInv = Euler {{ gasGamma = gasGamma, numericalFlux = "lax" }},
+      init = function(t, xn)
+         local x = xn[1]
+         
+         local rho = n * me
+         local vx = -vDrift
+         local vy = 0
+         local vz = 0
+         local p = n * T
+         local e = p / (gasGamma-1) + 0.5 * rho * (vx*vx + vy*vy + vz*vz)
+
+         return rho, rho*vx, rho*vy, rho*vz, e
+      end,
+      evolve = true,
+   }},
+
+   field = Moments.Field {{
+      epsilon0 = epsilon0,
+      mu0 = mu0,
+      init = function (t, xn)
+         local x = xn[1]
+         local Ex, Ey, Ez = 0, 0, 0
+         local Bx, By, Bz = 0, 0, 0
+         local phiE, PhiB = 0, 0
+         return Ex, Ey, Ez, Bx, By, Bz, phiE, phiB
+      end,
+      evolve = true,
+   }},
+
+   emSource = Moments.CollisionlessEmSource {{
+      species = {{"e1", "e2"}},
+      timeStepper = "direct",
+   }},   
+
+}}
+
+app:run()
+""".format(
+    vDrift__vTe=args.vDrift__vTe,
+    kx_de=args.kx_de,
+    pert=args.pert,
+    nProcs=args.nProcs,
+    tEnd_wpe=args.tEnd_wpe,
+    nFrame=args.nFrame,
+    Nx=args.Nx,
+)
+
+with open(args.filename, "w") as script_file:
+    script_file.write(input_str)

--- a/Regression/mom-two-stream/generate-rt-two-stream-5m.py
+++ b/Regression/mom-two-stream/generate-rt-two-stream-5m.py
@@ -46,6 +46,8 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
+print(f"\n{args}\n")
+
 input_str = """
 -- 1d 5-moment simulation of two-stream instability with two counter-streaming electron
 -- species, with an immobile ion species (that is not evolved).
@@ -203,15 +205,7 @@ app = Moments.App {{
 }}
 
 app:run()
-""".format(
-    vDrift__vTe=args.vDrift__vTe,
-    kx_de=args.kx_de,
-    pert=args.pert,
-    nProcs=args.nProcs,
-    tEnd_wpe=args.tEnd_wpe,
-    nFrame=args.nFrame,
-    Nx=args.Nx,
-)
+""".format(**vars(args))
 
 with open(args.filename, "w") as script_file:
     script_file.write(input_str)

--- a/Regression/mom-two-stream/generate-rt-two-stream-5m.py
+++ b/Regression/mom-two-stream/generate-rt-two-stream-5m.py
@@ -1,6 +1,10 @@
 import argparse
 
-parser = argparse.ArgumentParser(description="Generate gkyl input file.")
+parser = argparse.ArgumentParser(
+    description=(
+        "Generate gkyl input file of the 5-moment simulation of two-stream instability."
+    )
+)
 parser.add_argument("filename", help="name of the gkyl lua input file to be generated")
 parser.add_argument(
     "--vDrift__vTe",
@@ -205,7 +209,9 @@ app = Moments.App {{
 }}
 
 app:run()
-""".format(**vars(args))
+""".format(
+    **vars(args)
+)
 
 with open(args.filename, "w") as script_file:
     script_file.write(input_str)

--- a/Regression/mom-two-stream/rt-two-stream-5m.lua
+++ b/Regression/mom-two-stream/rt-two-stream-5m.lua
@@ -18,7 +18,6 @@
 ------------------------
 
 -- Parameters that should not be changed
-
 gasGamma = 3.0 -- adiabatic gas gamma, typically (f+3) / f where if is degree of freedom
 -- Light speed is needed for any EM simulation. A large value is chosen to minimize the
 -- impact of the EM effects over ES effects.
@@ -34,7 +33,7 @@ qe = -1.0 -- charge
 
 -- Physical parameters intended to be changed for parameter scanning
 vDrift__vTe = 5.0 -- drift velocity / thermal velocity
-kx_de = 0.5 -- wavenumber * Debye length
+kx_de = 0.1 -- wavenumber * Debye length
 pert = 1.0e-3 -- perturbation magnitude to the uniform background density
 
 -- Computational paremters
@@ -71,6 +70,7 @@ log("%30s = %g", "Nx", Nx)
 log("%30s = %g", "nFrame", nFrame)
 log("%30s = %g", "tEnd / nFrame", tEnd / nFrame)
 log("%30s = %g", "lightSpeed / vTe", lightSpeed / vTe)
+log("")
 
 ----------------------------------------
 -- CREATING AND RUNNING THE GKYL APPS --

--- a/Regression/mom-two-stream/rt-two-stream-5m.lua
+++ b/Regression/mom-two-stream/rt-two-stream-5m.lua
@@ -1,3 +1,4 @@
+
 -- 1d 5-moment simulation of two-stream instability with two counter-streaming electron
 -- species, with an immobile ion species (that is not evolved).
 --
@@ -34,7 +35,7 @@ qe = -1.0 -- charge
 -- Physical parameters intended to be changed for parameter scanning
 vDrift__vTe = 5.0 -- drift velocity / thermal velocity
 kx_de = 0.1 -- wavenumber * Debye length
-pert = 1.0e-3 -- perturbation magnitude to the uniform background density
+pert = 0.001 -- perturbation magnitude to the uniform background density
 
 -- Computational paremters
 nProcs = 1 -- number of processors for parallel computing

--- a/Regression/mom-two-stream/rt-two-stream-5m.lua
+++ b/Regression/mom-two-stream/rt-two-stream-5m.lua
@@ -1,0 +1,156 @@
+-- 1d 5-moment simulation of two-stream instability with two counter-streaming electron
+-- species, with an immobile ion species (that is not evolved).
+--
+-- 1. Note that though the problem is essentially electrostatic, i.e., without any
+-- magnetic fluctuations expected to develop, the model being used here is
+-- electromagnetic. In this case, magnetic fluctuations will be no more than the machine
+-- error. It is critical to note that using an EM model to mimic a ES problem does not
+-- always work. It works in this case because it is 1d and there is no net current.
+--
+-- 2. This input deck allows the user to specify the wavenumber, and then the domain
+-- length is set to fit exactly one wavelength.
+--
+-- 3. One educational study is to vary the value of vDrift and / or the wavenumber to
+-- compare the growth rates.
+
+------------------------
+-- SETTING PARAMETERS --
+------------------------
+
+-- Parameters that should not be changed
+
+gasGamma = 3.0 -- adiabatic gas gamma, typically (f+3) / f where if is degree of freedom
+-- Light speed is needed for any EM simulation. A large value is chosen to minimize the
+-- impact of the EM effects over ES effects.
+lightSpeed = 100.0
+epsilon0 = 1.0 -- vacuum permittivity
+
+-- Properties of the streaming species (assumed to beelectron). Note that the following
+-- values lead to Debye length and plasma frequency of numerical values 1.
+vTe = 1.0 -- thermal velocity
+n = 1.0 -- background number density
+me = 1.0 -- mass
+qe = -1.0 -- charge
+
+-- Physical parameters intended to be changed for parameter scanning
+vDrift__vTe = 5.0 -- drift velocity / thermal velocity
+kx_de = 0.5 -- wavenumber * Debye length
+pert = 1.0e-3 -- perturbation magnitude to the uniform background density
+
+-- Computational paremters
+nProcs = 1 -- number of processors for parallel computing
+tEnd_wpe = 40.0 -- simulation time * plasma frequency
+nFrame = 10 -- number of output frames excluding the initial condition
+Nx = 128 -- number of cells for discretization
+
+-- Derived parameters
+mu0 = 1 / lightSpeed^2 / epsilon0 -- vacuum permeability
+vDrift = vDrift__vTe * vTe -- drift velocity
+T = me * vTe^2 -- temperature
+de = math.sqrt(epsilon0 / qe^2 * T / n) -- Debye length
+kx = kx_de / de -- wavenumber
+Lx = math.pi / kx -- domain length
+wpe = math.sqrt(n * qe^2 / me / epsilon0) -- plasma frequency
+tEnd = tEnd_wpe / wpe
+
+-----------------------------------
+-- SHOWING SIMULATION PARAMETERS --
+-----------------------------------
+
+local Logger = require "Logger"
+local logger = Logger {logToFile = True}
+local log = function(...) logger(string.format(...).."\n") end
+
+log("")
+log("%30s = %g, %g", "Debye length, plasma frequency", de, wpe)
+log("%30s = %g, %g", "vDrift / vTe, vDrift", vDrift / vTe, vDrift)
+log("%30s = %g, %g", "kx * Debye length", kx * de, kx)
+log("%30s = %g, %g", "tEnd * Plasma frequency", tEnd * wpe, tEnd)
+log("%30s = %g", "perturbation level", pert)
+log("%30s = %g", "Nx", Nx)
+log("%30s = %g", "nFrame", nFrame)
+log("%30s = %g", "tEnd / nFrame", tEnd / nFrame)
+log("%30s = %g", "lightSpeed / vTe", lightSpeed / vTe)
+
+----------------------------------------
+-- CREATING AND RUNNING THE GKYL APPS --
+----------------------------------------
+
+local Moments = require("App.PlasmaOnCartGrid").Moments()
+local Euler = require "Eq.Euler"
+
+app = Moments.App {
+
+   tEnd = tEnd, -- end of simulation time
+   nFrame = nFrame, -- number of output frames
+   lower = {0}, -- lower limit of domain
+   upper = {Lx}, -- upper limit of domain
+   cells = {Nx}, -- number of cells to discretize the domain
+   decompCuts = {nProcs}, -- domain decomposition
+   periodicDirs = {1}, -- directions with periodic boundary conditions; 1:x, 2:y, 3:z
+   timeStepper = "fvDimSplit", -- dimensional-splitting finite-volume algorithm
+   logToFile = true,
+
+   -- right-going species
+   e1 = Moments.Species {
+      charge = qe,
+      mass = me,
+      equation = Euler { gasGamma = gasGamma },
+      equationInv = Euler { gasGamma = gasGamma, numericalFlux = "lax" },
+      init = function(t, xn)
+         local x = xn[1]
+         
+         local rho = n * me
+         local vx = vDrift
+         local vy = 0
+         local vz = 0
+         local p = n * T * (1 + pert * math.cos(kx * x))
+         local e = p / (gasGamma-1) + 0.5 * rho * (vx*vx + vy*vy + vz*vz)
+
+         return rho, rho*vx, rho*vy, rho*vz, e
+      end,
+      evolve = true,
+   },
+
+   -- left-going species
+   e2 = Moments.Species {
+      charge = qe,
+      mass = me,
+      equation = Euler { gasGamma = gasGamma },
+      equationInv = Euler { gasGamma = gasGamma, numericalFlux = "lax" },
+      init = function(t, xn)
+         local x = xn[1]
+         
+         local rho = n * me
+         local vx = -vDrift
+         local vy = 0
+         local vz = 0
+         local p = n * T
+         local e = p / (gasGamma-1) + 0.5 * rho * (vx*vx + vy*vy + vz*vz)
+
+         return rho, rho*vx, rho*vy, rho*vz, e
+      end,
+      evolve = true,
+   },
+
+   field = Moments.Field {
+      epsilon0 = epsilon0,
+      mu0 = mu0,
+      init = function (t, xn)
+         local x = xn[1]
+         local Ex, Ey, Ez = 0, 0, 0
+         local Bx, By, Bz = 0, 0, 0
+         local phiE, PhiB = 0, 0
+         return Ex, Ey, Ez, Bx, By, Bz, phiE, phiB
+      end,
+      evolve = true,
+   },
+
+   emSource = Moments.CollisionlessEmSource {
+      species = {"e1", "e2"},
+      timeStepper = "direct",
+   },   
+
+}
+
+app:run()


### PR DESCRIPTION
- `Regression/mom-two-stream/generate-rt-two-stream-5m.py`
- `Regression/mom-magnetosphere/generate-msphere3d.py`


To see usage, use `-h` option; e.g.,
```
$ python ~/src/gkyl.master/Regression/mom-two-stream/generate-rt-two-stream-5m.py -h
usage: generate-rt-two-stream-5m.py [-h] [--vDrift__vTe VDRIFT__VTE] [--kx_de KX_DE] [--pert PERT]
                                    [--tEnd_wpe TEND_WPE] [--nFrame NFRAME] [--Nx NX] [--nProcs NPROCS]
                                    filename

Generate gkyl input file of the 5-moment simulation of two-stream instability.

positional arguments:
  filename              name of the gkyl lua input file to be generated

options:
  -h, --help            show this help message and exit
  --vDrift__vTe VDRIFT__VTE
                        drift velocity / thermal velocity
  --kx_de KX_DE         wavenumber * Debye length
  --pert PERT           perturbation magnitude to the uniform background density
  --tEnd_wpe TEND_WPE   simulation time * plasma frequency
  --nFrame NFRAME       number of output frames excluding the initial condition
  --Nx NX               number of cells for discretization
  --nProcs NPROCS       number of processors for parallel computing
```