### PR TITLE
Remove ext field from auxfields and adapt Vlasov app for VP w/ external field

### DIFF
--- a/App/Field/FieldBase.lua
+++ b/App/Field/FieldBase.lua
@@ -11,6 +11,7 @@ local Proto = require "Lib.Proto"
 -- Empty shell field base classes.
 local FieldBase = Proto()
 function FieldBase:init(tbl) self.isElliptic = false end
+function FieldBase:fullInit(tbl, plasmaField) end
 function FieldBase:readRestart() end
 function FieldBase:hasEB() return nil, nil end
 function FieldBase:setCfl() end
@@ -34,6 +35,7 @@ function FieldBase:clearTimers() end
 
 local ExternalFieldBase = Proto()
 function ExternalFieldBase:init(tbl) self.isElliptic = false end
+function ExternalFieldBase:fullInit(tbl, plasmaField) end
 function ExternalFieldBase:hasEB() return nil, nil end
 function ExternalFieldBase:setCfl() end
 function ExternalFieldBase:setIoMethod(ioMethod) self.ioMethod = ioMethod end
@@ -58,7 +60,7 @@ local NoField = Proto(FieldBase)
 
 -- Methods for no field object.
 function NoField:init(tbl) NoField.super.init(tbl) end
-function NoField:fullInit(tbl) end
+function NoField:fullInit(tbl, plasmaField) end
 function NoField:hasEB() return nil, nil end
 function NoField:setCfl() end
 function NoField:setIoMethod(ioMethod) end

--- a/App/Field/MaxwellField.lua
+++ b/App/Field/MaxwellField.lua
@@ -707,7 +707,11 @@ function ExternalMaxwellField:fullInit(appTbl, plasmaField)
    self.evolve = xsys.pickBool(tbl.evolve, true) -- By default evolve field.
 
    -- By default there is a plasma-generated magnetic field, unless running Vlasov-Poisson.
-   self.hasPlasmaMagField = xsys.pickBool(plasmaField and plasmaField.hasMagField or nil, true)
+   if plasmaField then
+      self.hasPlasmaMagField = xsys.pickBool(plasmaField.hasMagField, true)
+   else
+      self.hasPlasmaMagField = true -- Assumption
+   end
 
    self.hasMagField = xsys.pickBool(tbl.hasMagneticField, true) -- By default there is a magnetic field.
 
@@ -762,7 +766,7 @@ function ExternalMaxwellField:alloc(nField)
 end
 
 function ExternalMaxwellField:createSolver(population)
-   self.fieldSlvr = Updater.ProjectOnBasis {
+   self.fieldSlvr = Updater.EvalOnNodes {
       onGrid = self.grid,   evaluate = self.emFunc,
       basis  = self.basis,  onGhosts = false,
    }

--- a/App/Field/MaxwellField.lua
+++ b/App/Field/MaxwellField.lua
@@ -69,7 +69,7 @@ end
 
 -- Actual function for initialization. This indirection is needed as
 -- we need the app top-level table for proper initialization.
-function MaxwellField:fullInit(appTbl)
+function MaxwellField:fullInit(appTbl, plasmaField)
    local tbl = self.tbl -- Previously store table.
    
    self.epsilon0 = tbl.epsilon0
@@ -300,9 +300,9 @@ function MaxwellField:alloc(nRkDup)
       self.emEnergy = DataStruct.DynVector { numComponents = 8 }
 
    else   -- Poisson equation.
-      -- Electrostatic potential, phi.
-      local phiFld = createField(self.grid, self.basis, ghostNum, self.basis:numBasis())
-      for i = 1, nRkDup do self.em[i] = phiFld end
+      -- Electrostatic potential, phi, and external magnetic potential A_ext (computed by ExternalField).
+      local potentials = createField(self.grid, self.basis, ghostNum, 4*self.basis:numBasis())
+      for i = 1, nRkDup do self.em[i] = potentials end
 
       -- Extra fields needed for the distributed parallel field solve.
       self.localBuffer  = createField(self.grid, self.basis, {0,0}, self.basis:numBasis())
@@ -687,14 +687,6 @@ function MaxwellField:clearTimers()
    for nm, _ in pairs(self.timers) do self.timers[nm] = 0. end
 end
  
-MaxwellField.bcConst = function(Ex, Ey, Ez, Bx, By, Bz, phiE, phiB)
-   local bc = BoundaryCondition.Const {
-      components = {1, 2, 3, 4, 5, 6, 7, 8},
-      values = {Ex, Ey, Ez, Bx, By, Bz, phiE, phiB}
-   }
-   return { bc }
-end
-  
 -- ExternalMaxwellField ---------------------------------------------------------------------
 --
 -- A field object with external EM fields specified as a time-dependent function.
@@ -708,11 +700,14 @@ function ExternalMaxwellField:init(tbl)
    self.tbl = tbl
 end
 
-function ExternalMaxwellField:fullInit(appTbl)
+function ExternalMaxwellField:fullInit(appTbl, plasmaField)
    local tbl = self.tbl -- Previously store table.
 
    self.ioMethod = "MPI"
    self.evolve = xsys.pickBool(tbl.evolve, true) -- By default evolve field.
+
+   -- By default there is a plasma-generated magnetic field, unless running Vlasov-Poisson.
+   self.hasPlasmaMagField = xsys.pickBool(plasmaField and plasmaField.hasMagField or nil, true)
 
    self.hasMagField = xsys.pickBool(tbl.hasMagneticField, true) -- By default there is a magnetic field.
 
@@ -725,16 +720,30 @@ function ExternalMaxwellField:fullInit(appTbl)
 
    self.ioFrame = 0 -- Frame number for IO.
    
-   -- Store function to compute EM field.
-   if self.hasMagField then
-      self.emFunc = function (t, xn)
-         local ex, ey, ez, bx, by, bz = tbl.emFunc(t, xn)
-         return ex, ey, ez, bx, by, bz, 0.0, 0.0
+   -- Store function to compute the external field.
+   if self.hasPlasmaMagField then
+      if self.hasMagField then
+         self.emFunc = function (t, xn)
+            local ex, ey, ez, bx, by, bz = tbl.emFunc(t, xn)
+            return ex, ey, ez, bx, by, bz, 0., 0.
+         end
+      else
+         self.emFunc = function (t, xn)
+            local ex, ey, ez = tbl.emFunc(t, xn)
+            return ex, ey, ez, 0., 0., 0., 0., 0.
+         end
       end
    else
-      self.emFunc = function (t, xn)
-         local ex, ey, ez = tbl.emFunc(t, xn)
-         return ex, ey, ez
+      if self.hasMagField then
+         self.emFunc = function (t, xn)
+            local phi, ax, ay, az = tal.emFunc(t, xn)
+            return phi, ax, ay, az
+         end
+      else
+         self.emFunc = function(t, xn)
+            local phi = tbl.emFunc(t, xn)
+            return phi, 0., 0., 0.
+         end
       end
    end
 
@@ -748,15 +757,14 @@ function ExternalMaxwellField:alloc(nField)
    local ghostNum = {1,1}
 
    -- Allocate fields needed in RK update.
-   local emVecComp = 8
-   if not self.hasMagField then emVecComp = 1 end  -- Electric field only.
+   local emVecComp = self.hasPlasmaMagField and 8 or 4
    self.em = createField(self.grid, self.basis, ghostNum, emVecComp*self.basis:numBasis())
 end
 
 function ExternalMaxwellField:createSolver(population)
    self.fieldSlvr = Updater.ProjectOnBasis {
       onGrid = self.grid,   evaluate = self.emFunc,
-      basis  = self.basis,  onGhosts = true,
+      basis  = self.basis,  onGhosts = false,
    }
       
    -- Create Adios object for field I/O.
@@ -774,7 +782,7 @@ end
 
 function ExternalMaxwellField:createDiagnostics() end
 
-function ExternalMaxwellField:initField()
+function ExternalMaxwellField:initField(population)
    self.fieldSlvr:advance(0.0, {}, {self.em})
    self:applyBc(0.0, self.em)
 end

--- a/App/PlasmaOnCartGrid.lua
+++ b/App/PlasmaOnCartGrid.lua
@@ -242,7 +242,7 @@ local function buildApplication(self, tbl)
    end
 
    local function completeFieldSetup(fld, plasmaField)
-      fld:fullInit(tbl, field) -- Complete initialization.
+      fld:fullInit(tbl, plasmaField) -- Complete initialization.
       fld:setIoMethod(ioMethod)
       fld:setBasis(confBasis)
       fld:setGrid(confGrid)

--- a/App/PlasmaOnCartGrid.lua
+++ b/App/PlasmaOnCartGrid.lua
@@ -241,8 +241,8 @@ local function buildApplication(self, tbl)
       s:setCfl(cflMin)
    end
 
-   local function completeFieldSetup(fld)
-      fld:fullInit(tbl) -- Complete initialization.
+   local function completeFieldSetup(fld, plasmaField)
+      fld:fullInit(tbl, field) -- Complete initialization.
       fld:setIoMethod(ioMethod)
       fld:setBasis(confBasis)
       fld:setGrid(confGrid)
@@ -269,7 +269,7 @@ local function buildApplication(self, tbl)
    for _, val in pairs(tbl) do
       if FieldBase.is(val) then
          field = val
-         completeFieldSetup(field)
+         completeFieldSetup(field, field)
          nfields = nfields + 1
       end
    end
@@ -282,7 +282,7 @@ local function buildApplication(self, tbl)
    for _, val in pairs(tbl) do
       if ExternalFieldBase.is(val) then
          externalField = val
-         completeFieldSetup(externalField)
+         completeFieldSetup(externalField, field)
          nfields = nfields + 1
       end
    end

--- a/App/Species/VlasovSpecies.lua
+++ b/App/Species/VlasovSpecies.lua
@@ -550,11 +550,10 @@ function VlasovSpecies:createSolver(field, externalField)
       hasE, hasB = true, true
    end
 
-   if hasB then
-      self.totalEmField = self:allocVectorMoment(8)     -- 8 components of EM field.
+   if plasmaB == false then
+      self.totalEmField = self:allocVectorMoment(4)  -- (phi,A) for Vlasov-Poisson.
    else
-      --self.totalEmField = self:allocVectorMoment(3)     -- Electric field only.
-      self.totalEmField = self:allocMoment()  -- Phi only (Vlasov-Poisson)
+      self.totalEmField = self:allocVectorMoment(8)  -- 8 components of EM field.
    end
 
    self.computePlasmaB = true and plasmaB or extHasB

--- a/Updater/VlasovDG.lua
+++ b/Updater/VlasovDG.lua
@@ -29,7 +29,6 @@ ffi.cdef [[
 // Struct containing the pointers to auxiliary fields.
 struct gkyl_dg_vlasov_auxfields { 
   const struct gkyl_array *field; // q/m*(E,B) for Maxwell's, q/m*phi for Poisson's (gradient calculated in kernel)
-  const struct gkyl_array *ext_field; // constant q/m*A for Poisson's (curl calculated in kernel)
   const struct gkyl_array *cot_vec; // cotangent vectors (e^i) used in volume term if general geometry enabled
   const struct gkyl_array *alpha_geo; // alpha^i (e^i . alpha) used in surface term if general geometry enabled
 };


### PR DESCRIPTION
this goes with gkylzero PR #211 (https://github.com/ammarhakim/gkylzero/pull/211)

The main fix here is to project the external field, now a potential, with EvalOnNodes rather than ProjectOnBasis. This removes a grid-scale mode that shows up when using external fields. I wonder if this was the source of problems in the nonlinear stage of some ion acoustic turbulence simulations when @nmandell tried to put them on a GPU a year or two ago.