### PR TITLE
Removing some old code from the wscript for Mac builds

### DIFF
--- a/machines/configure.macosx.sh
+++ b/machines/configure.macosx.sh
@@ -3,8 +3,8 @@
 # Build directory
 OUT=build
 # Install location
-PREFIX=$HOME/gkylsoft/gkyl
 GKYLSOFT=$HOME/gkylsoft
+PREFIX=$GKYLSOFT/gkyl
 
 # Compile flags (set optimization/debug flags here)
 CC=clang

--- a/machines/mkdeps.macosx.sh
+++ b/machines/mkdeps.macosx.sh
@@ -6,7 +6,7 @@ fi
 export GKYLSOFT='~/gkylsoft'
 cd install-deps
 # first build OpenMPI
-./mkdeps.sh CC=clang CXX=clang++ --build-openmpi=yes
+./mkdeps.sh CC=clang CXX=clang++ --build-openmpi=yes --prefix=$GKYLSOFT
 # get OSX version (XX.XX.X)
 vers=`sw_vers -productVersion`   
 # remove patch version, so that only XX.XX

--- a/wscript
+++ b/wscript
@@ -234,9 +234,6 @@ def appendToList(target, val):
         
 def buildExec(bld):
     r"""Build top-level executable"""
-    if platform.system() == 'Darwin' and platform.machine() == 'x86_64':
-        # we need to append special flags to get stuff to work on a 64 bit Mac
-        EXTRA_LINK_FLAGS.append('-pagezero_size 10000 -image_base 100000000')
 
     # Link flags on Linux
     if platform.system() == 'Linux':


### PR DESCRIPTION
This code was necessary to build on Mac 7+ years ago, but now seems to actually break the build with the latest clang on OSX Sonoma and causes issues with the Mac ARM chips on OSX Ventura. Fortunately doesn't seem to break older Mac OS builds (perhaps because clang has changed a bit since 2016)