### PR TITLE
Changing how the LBO pointers are set on the G2 side based on some recent cleanup of the G0 app

### DIFF
--- a/wscript
+++ b/wscript
@@ -229,9 +229,6 @@ def appendToList(target, val):
         
 def buildExec(bld):
     r"""Build top-level executable"""
-    if platform.system() == 'Darwin' and platform.machine() == 'x86_64':
-        # we need to append special flags to get stuff to work on a 64 bit Mac
-        EXTRA_LINK_FLAGS.append('-pagezero_size 10000 -image_base 100000000')
 
     # Link flags on Linux
     if platform.system() == 'Linux':


### PR DESCRIPTION
We now set the pointers in the LBO once at initialization, similar to how Vlasov works (and VlasovDG.lua in G2). Goes with branch https://github.com/ammarhakim/gkylzero/tree/app-cleanup which mostly focuses on the G0 level.

Note that this branch also removes some unneeded link flags on Macs that cause issues and I am not sure why they were added back in. 

Regression tests pass.