### PR TITLE
Fix eqdskreader

### DIFF
--- a/Tool/eqdskreader.lua
+++ b/Tool/eqdskreader.lua
@@ -188,15 +188,13 @@ for i = 1, nx do
 end
 
 -- read (R,Z) coordinates of LCFS
-local sepR = DataStruct.DynVector { numComponents = 1 }
-local sepZ = DataStruct.DynVector { numComponents = 1 }
+local sepRZ = DataStruct.DynVector { numComponents = 2 }
 
 local nbbbs = dataItr:next()
 local limtr = dataItr:next()
 
 for i = 1, nbbbs do
-   sepR:appendData(i, { dataItr:next() } )
-   sepZ:appendData(i, { dataItr:next() } )
+   sepRZ:appendData(i, { dataItr:next(), dataItr:next() } )
 end
 
 -- write data to BP files
@@ -206,5 +204,4 @@ ffprime:write("ffprime.bp")
 pprime:write("pprime.bp")
 psi:write("psi.bp")
 qpsi:write("qpsi.bp")
-sepR:write("sepR.bp")
-sepZ:write("sepZ.bp")
+sepRZ:write("sepRZ.bp")

--- a/Tool/eqdskreader.lua
+++ b/Tool/eqdskreader.lua
@@ -11,6 +11,11 @@ local DataStruct = require "DataStruct"
 local Grid = require "Grid"
 local argparse = require "Lib.argparse"
 
+local Mpi = require "Comm.Mpi"
+local Adios = require "Io.Adios"
+
+GKYL_ADIOS2_MPI = GKYL_ADIOS2_MPI or Adios.init_mpi(Mpi.COMM_WORLD)
+
 -- Create CLI parser to handle commands and options
 local parser = argparse()
    :name("eqdskreader")
@@ -114,8 +119,8 @@ local metaData = {
 
 -- create grids
 local grid1d = Grid.RectCart {
-   lower = { rleft },
-   upper = { rleft + rdim },
+   lower = { simag },
+   upper = { sibry },
    cells = { nx }
 }
 local grid2d = Grid.RectCart {

--- a/Tool/eqdskreader.lua
+++ b/Tool/eqdskreader.lua
@@ -108,7 +108,10 @@ function Iter1D:seek(idx)
    self.currIdx = idx
 end
 function Iter1D:next()
-   local val = self.arr[self.currIdx]
+   local val = 0
+   if self.currIdx <= self.arr:size() then
+      val = self.arr[self.currIdx]
+   end
    self.currIdx = self.currIdx+1
    return val
 end
@@ -184,17 +187,24 @@ for i = 1, nx do
    qpsi:get(i)[1] = dataItr:next()
 end
 
+-- read (R,Z) coordinates of LCFS
+local sepR = DataStruct.DynVector { numComponents = 1 }
+local sepZ = DataStruct.DynVector { numComponents = 1 }
+
 local nbbbs = dataItr:next()
 local limtr = dataItr:next()
 
 for i = 1, nbbbs do
-   
+   sepR:appendData(i, { dataItr:next() } )
+   sepZ:appendData(i, { dataItr:next() } )
 end
 
--- write data to BP file
+-- write data to BP files
 fpol:write("fpol.bp")
 pres:write("pres.bp")
 ffprime:write("ffprime.bp")
 pprime:write("pprime.bp")
 psi:write("psi.bp")
 qpsi:write("qpsi.bp")
+sepR:write("sepR.bp")
+sepZ:write("sepZ.bp")


### PR DESCRIPTION
Fixed the eqdskreader Tool. We can now read eqdsk files and write out all its data into BP files. These files can be used in pgkyl for viz. The goal is to use BP files for the various inputs needed in the GK geometry code. Reading eqdsk is messy and perhaps it is best to do this step as pre-processing step instead.